### PR TITLE
fix(security): replace realistic PII with dummy data

### DIFF
--- a/src/components/figma/ImageWithFallback.tsx
+++ b/src/components/figma/ImageWithFallback.tsx
@@ -18,7 +18,7 @@ export function ImageWithFallback(props: React.ImgHTMLAttributes<HTMLImageElemen
       style={style}
     >
       <div className="flex items-center justify-center w-full h-full">
-        <img src={ERROR_IMG_SRC} alt="Error loading image" {...rest} data-original-url={src} />
+        <img src={ERROR_IMG_SRC} alt="Error loading image" {...rest} />
       </div>
     </div>
   ) : (

--- a/src/components/hospital/StaffManagement.tsx
+++ b/src/components/hospital/StaffManagement.tsx
@@ -52,15 +52,15 @@ const mockStaff: StaffMember[] = [
     department: '응급의학과',
     shift: 'day',
     status: 'on-duty',
-    phone: '010-1234-5678',
-    email: 'kim.doctor@hospital.com',
+    phone: '010-0000-0001',
+    email: 'staff1@example.com',
     specialization: '외상외과',
     yearsOfExperience: 8,
     currentLocation: '응급실 A구역',
     shiftStart: '08:00',
     shiftEnd: '18:00',
     certifications: ['ACLS', 'ATLS', 'BLS'],
-    emergencyContact: '010-9876-5432'
+    emergencyContact: '010-0000-1001'
   },
   {
     id: 'DOC002',
@@ -69,15 +69,15 @@ const mockStaff: StaffMember[] = [
     department: '응급의학과',
     shift: 'night',
     status: 'off-duty',
-    phone: '010-2345-6789',
-    email: 'lee.doctor@hospital.com',
+    phone: '010-0000-0002',
+    email: 'staff2@example.com',
     specialization: '내과',
     yearsOfExperience: 12,
     currentLocation: '대기실',
     shiftStart: '18:00',
     shiftEnd: '08:00',
     certifications: ['ACLS', 'BLS', 'PALS'],
-    emergencyContact: '010-8765-4321'
+    emergencyContact: '010-0000-1002'
   },
   {
     id: 'NUR001',
@@ -86,14 +86,14 @@ const mockStaff: StaffMember[] = [
     department: '응급실',
     shift: 'day',
     status: 'on-duty',
-    phone: '010-3456-7890',
-    email: 'park.nurse@hospital.com',
+    phone: '010-0000-0003',
+    email: 'staff3@example.com',
     yearsOfExperience: 5,
     currentLocation: '응급실 B구역',
     shiftStart: '08:00',
     shiftEnd: '18:00',
     certifications: ['BLS', 'ACLS'],
-    emergencyContact: '010-7654-3210'
+    emergencyContact: '010-0000-1003'
   },
   {
     id: 'NUR002',
@@ -102,14 +102,14 @@ const mockStaff: StaffMember[] = [
     department: '응급실',
     shift: 'evening',
     status: 'break',
-    phone: '010-4567-8901',
-    email: 'choi.nurse@hospital.com',
+    phone: '010-0000-0004',
+    email: 'staff4@example.com',
     yearsOfExperience: 3,
     currentLocation: '휴게실',
     shiftStart: '14:00',
     shiftEnd: '22:00',
     certifications: ['BLS'],
-    emergencyContact: '010-6543-2109'
+    emergencyContact: '010-0000-1004'
   },
   {
     id: 'TEC001',
@@ -118,15 +118,15 @@ const mockStaff: StaffMember[] = [
     department: '방사선과',
     shift: 'day',
     status: 'on-duty',
-    phone: '010-5678-9012',
-    email: 'jung.tech@hospital.com',
+    phone: '010-0000-0005',
+    email: 'staff5@example.com',
     specialization: 'X-ray, CT',
     yearsOfExperience: 7,
     currentLocation: '영상의학과',
     shiftStart: '08:00',
     shiftEnd: '18:00',
     certifications: ['방사선사', 'CT 전문'],
-    emergencyContact: '010-5432-1098'
+    emergencyContact: '010-0000-1005'
   },
   {
     id: 'ADM001',
@@ -135,14 +135,14 @@ const mockStaff: StaffMember[] = [
     department: '응급실 관리',
     shift: 'day',
     status: 'on-duty',
-    phone: '010-6789-0123',
-    email: 'song.admin@hospital.com',
+    phone: '010-0000-0006',
+    email: 'staff6@example.com',
     yearsOfExperience: 10,
     currentLocation: '관리실',
     shiftStart: '08:00',
     shiftEnd: '18:00',
     certifications: ['병원관리사'],
-    emergencyContact: '010-4321-0987'
+    emergencyContact: '010-0000-1006'
   }
 ];
 


### PR DESCRIPTION
## Summary
- 목업 직원 데이터의 전화번호/이메일/비상연락처를 명확한 더미값(example.com)으로 교체
- ImageWithFallback에서 `data-original-url` DOM 속성 제거

Closes #2

## Test plan
- [ ] 빌드 정상 확인
- [ ] StaffManagement 페이지에서 더미 데이터 표시 확인
- [ ] ImageWithFallback 에러 시 data-original-url 미노출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)