### PR TITLE
perf: optimize rendering by extracting static data and memoizing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,20 +25,19 @@ import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigge
 
 type CurrentPage = 'dashboard' | 'patients' | 'beds' | 'staff' | 'equipment' | 'request';
 
-function App() {
-  return (
-    <ThemeProvider defaultTheme="system" storageKey="rescue-one-theme">
-      <AppContent />
-      <Toaster />
-    </ThemeProvider>
-  );
-}
+const navigationItems = [
+  { id: 'dashboard', label: '대시보드', icon: Home },
+  { id: 'patients', label: '환자 관리', icon: Users },
+  { id: 'beds', label: '병상 관리', icon: Bed },
+  { id: 'staff', label: '직원 관리', icon: UserCheck },
+  { id: 'equipment', label: '장비 현황', icon: Stethoscope },
+  { id: 'request', label: '구급대원 요청', icon: Ambulance },
+] as const;
 
-function AppContent() {
-  const [currentPage, setCurrentPage] = useState<CurrentPage>('dashboard');
+function ThemeToggle() {
   const { theme, setTheme } = useTheme();
 
-  const ThemeToggle = () => (
+  return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <Button variant="outline" size="sm">
@@ -63,15 +62,19 @@ function AppContent() {
       </DropdownMenuContent>
     </DropdownMenu>
   );
+}
 
-  const navigationItems = [
-    { id: 'dashboard', label: '대시보드', icon: Home },
-    { id: 'patients', label: '환자 관리', icon: Users },
-    { id: 'beds', label: '병상 관리', icon: Bed },
-    { id: 'staff', label: '직원 관리', icon: UserCheck },
-    { id: 'equipment', label: '장비 현황', icon: Stethoscope },
-    { id: 'request', label: '구급대원 요청', icon: Ambulance },
-  ] as const;
+function App() {
+  return (
+    <ThemeProvider defaultTheme="system" storageKey="rescue-one-theme">
+      <AppContent />
+      <Toaster />
+    </ThemeProvider>
+  );
+}
+
+function AppContent() {
+  const [currentPage, setCurrentPage] = useState<CurrentPage>('dashboard');
 
   return (
     <div className="min-h-screen bg-background">

--- a/src/components/hospital/HospitalDashboard.tsx
+++ b/src/components/hospital/HospitalDashboard.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
 import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
@@ -24,6 +24,12 @@ import {
 import { toast } from "sonner";
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, PieChart, Pie, Cell } from 'recharts';
 
+const recentAlerts = [
+  { time: '5분 전', message: '중증 환자 3명 동시 접수', type: 'warning' },
+  { time: '12분 전', message: '병상 가용률 80% 달성', type: 'info' },
+  { time: '20분 전', message: '응급실 대기시간 단축', type: 'success' },
+];
+
 export function HospitalDashboard() {
   const [accepting, setAccepting] = useState(true);
   const [requests, setRequests] = useState(generateMockRequests());
@@ -47,16 +53,13 @@ export function HospitalDashboard() {
     ? requests.filter(req => req.status === 'pending')
     : requests.filter(req => req.status === 'pending' && req.severity.toString() === selectedSeverity);
 
-  const getKPIData = () => {
+  const kpiData = useMemo(() => {
     const availableBeds = 8;
     const erQueue = requests.filter(req => req.status === 'matched').length;
     const avgWaitTime = 25;
     const todayProcessed = requests.filter(req => req.status === 'completed').length;
-
     return { availableBeds, erQueue, avgWaitTime, todayProcessed };
-  };
-
-  const kpiData = getKPIData();
+  }, [requests]);
 
   const getSeverityColor = (severity: number) => {
     if (severity >= 4) return 'destructive';
@@ -76,21 +79,17 @@ export function HospitalDashboard() {
   };
 
   // 차트 데이터
-  const hourlyLoadData = Array.from({ length: 24 }, (_, i) => ({
-    hour: `${i}:00`,
-    patients: Math.floor(Math.random() * 15 + 5)
-  }));
+  const [hourlyLoadData] = useState(() =>
+    Array.from({ length: 24 }, (_, i) => ({
+      hour: `${i}:00`,
+      patients: Math.floor(Math.random() * 15 + 5)
+    }))
+  );
 
   const severityDistributionData = [
     { name: '경미', value: requests.filter(r => r.severity <= 2).length, color: '#10b981' },
     { name: '보통', value: requests.filter(r => r.severity === 3).length, color: '#f59e0b' },
     { name: '심각', value: requests.filter(r => r.severity >= 4).length, color: '#ef4444' },
-  ];
-
-  const recentAlerts = [
-    { time: '5분 전', message: '중증 환자 3명 동시 접수', type: 'warning' },
-    { time: '12분 전', message: '병상 가용률 80% 달성', type: 'info' },
-    { time: '20분 전', message: '응급실 대기시간 단축', type: 'success' },
   ];
 
   return (

--- a/src/components/paramedic/ParamedicDashboard.tsx
+++ b/src/components/paramedic/ParamedicDashboard.tsx
@@ -21,6 +21,12 @@ import {
 } from 'lucide-react';
 import { toast } from "sonner";
 
+const recentEvents = [
+  { time: '10분 전', message: '서울대병원 수용 가능 상태 전환', type: 'info' },
+  { time: '15분 전', message: 'Case #RQ-1023 배정 완료', type: 'success' },
+  { time: '23분 전', message: '응급호출 3건 신규 접수', type: 'warning' },
+];
+
 export function ResponderDashboard() {
   const [isOnline, setIsOnline] = useState(true);
   const [selectedFilter, setSelectedFilter] = useState('all');
@@ -37,7 +43,7 @@ export function ResponderDashboard() {
       acc[req.status] = (acc[req.status] || 0) + 1;
       return acc;
     }, {} as Record<string, number>);
-    
+
     return {
       pending: counts.pending || 0,
       matched: counts.matched || 0,
@@ -61,12 +67,6 @@ export function ResponderDashboard() {
       default: return <Activity size={16} />;
     }
   };
-
-  const recentEvents = [
-    { time: '10분 전', message: '서울대병원 수용 가능 상태 전환', type: 'info' },
-    { time: '15분 전', message: 'Case #RQ-1023 배정 완료', type: 'success' },
-    { time: '23분 전', message: '응급호출 3건 신규 접수', type: 'warning' },
-  ];
 
   return (
     <div className="space-y-6">


### PR DESCRIPTION
## Summary
- ThemeToggle을 AppContent 내부에서 파일 스코프 독립 컴포넌트로 분리
- navigationItems, recentAlerts 정적 배열을 모듈 스코프로 이동
- hourlyLoadData를 useState 초기값으로 변경 (매 렌더 Math.random 제거)
- getKPIData를 useMemo로 변환

Closes #11

## Test plan
- [ ] 빌드 정상 확인
- [ ] 대시보드 차트가 토글/필터 시 안정적으로 유지되는지 확인
- [ ] 테마 전환 정상 작동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)