### PR TITLE
refactor: remove unused code and apply React.lazy code splitting

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,18 +1,12 @@
-import { useState } from 'react';
+import { useState, Suspense, lazy } from 'react';
 import { Button } from "./components/ui/button";
 import { Badge } from "./components/ui/badge";
-import { HospitalDashboard } from "./components/hospital/HospitalDashboard";
-import { PatientDetails } from "./components/hospital/PatientDetails";
-import { BedManagement } from "./components/hospital/BedManagement";
-import { StaffManagement } from "./components/hospital/StaffManagement";
-import { EquipmentStatus } from "./components/hospital/EquipmentStatus";
-import { PatientRequest } from "./components/responder/PatientRequest";
 import { ThemeProvider, useTheme } from "./components/theme/ThemeProvider";
 import { Toaster } from "./components/ui/sonner";
-import { 
-  Building2, 
-  Sun, 
-  Moon, 
+import {
+  Building2,
+  Sun,
+  Moon,
   Monitor,
   Home,
   Users,
@@ -22,6 +16,13 @@ import {
   Ambulance
 } from 'lucide-react';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "./components/ui/dropdown-menu";
+
+const HospitalDashboard = lazy(() => import('./components/hospital/HospitalDashboard').then(m => ({ default: m.HospitalDashboard })));
+const PatientDetails = lazy(() => import('./components/hospital/PatientDetails').then(m => ({ default: m.PatientDetails })));
+const BedManagement = lazy(() => import('./components/hospital/BedManagement').then(m => ({ default: m.BedManagement })));
+const StaffManagement = lazy(() => import('./components/hospital/StaffManagement').then(m => ({ default: m.StaffManagement })));
+const EquipmentStatus = lazy(() => import('./components/hospital/EquipmentStatus').then(m => ({ default: m.EquipmentStatus })));
+const PatientRequest = lazy(() => import('./components/paramedic/PatientRequest').then(m => ({ default: m.PatientRequest })));
 
 type CurrentPage = 'dashboard' | 'patients' | 'beds' | 'staff' | 'equipment' | 'request';
 
@@ -138,12 +139,14 @@ function AppContent() {
       </div>
 
       <div className="container mx-auto px-4 py-6">
-        {currentPage === 'dashboard' && <HospitalDashboard />}
-        {currentPage === 'patients' && <PatientDetails />}
-        {currentPage === 'beds' && <BedManagement />}
-        {currentPage === 'staff' && <StaffManagement />}
-        {currentPage === 'equipment' && <EquipmentStatus />}
-        {currentPage === 'request' && <PatientRequest />}
+        <Suspense fallback={<div className="flex items-center justify-center h-64"><p>로딩 중...</p></div>}>
+          {currentPage === 'dashboard' && <HospitalDashboard />}
+          {currentPage === 'patients' && <PatientDetails />}
+          {currentPage === 'beds' && <BedManagement />}
+          {currentPage === 'staff' && <StaffManagement />}
+          {currentPage === 'equipment' && <EquipmentStatus />}
+          {currentPage === 'request' && <PatientRequest />}
+        </Suspense>
       </div>
     </div>
   );

--- a/src/components/common/InfoCard.tsx
+++ b/src/components/common/InfoCard.tsx
@@ -1,3 +1,4 @@
+import type React from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
 import { Badge } from "../ui/badge";
 

--- a/src/components/paramedic/ParamedicDashboard.tsx
+++ b/src/components/paramedic/ParamedicDashboard.tsx
@@ -7,13 +7,10 @@ import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTr
 import { InfoCard, StatChip } from "../common/InfoCard";
 import { MiniMapPlaceholder } from "../common/MiniMapPlaceholder";
 import { generateMockRequests, generateMockHospitals, MockHospital } from "../common/models";
-import { 
-  Ambulance, 
-  Phone, 
-  Share2, 
-  Heart, 
-  Brain, 
-  Activity,
+import {
+  Ambulance,
+  Phone,
+  Share2,
   Clock,
   MapPin,
   AlertTriangle,
@@ -27,9 +24,8 @@ const recentEvents = [
   { time: '23분 전', message: '응급호출 3건 신규 접수', type: 'warning' },
 ];
 
-export function ResponderDashboard() {
+export function ParamedicDashboard() {
   const [isOnline, setIsOnline] = useState(true);
-  const [selectedFilter, setSelectedFilter] = useState('all');
   const [hospitals] = useState(generateMockHospitals());
   const [requests] = useState(generateMockRequests());
 
@@ -53,20 +49,6 @@ export function ResponderDashboard() {
   };
 
   const statusCounts = getStatusCounts();
-
-  const getSeverityColor = (severity: number) => {
-    if (severity >= 4) return 'destructive';
-    if (severity >= 3) return 'warning';
-    return 'success';
-  };
-
-  const getSpecialtyIcon = (specialty: string) => {
-    switch (specialty) {
-      case '심장내과': return <Heart size={16} />;
-      case '신경외과': return <Brain size={16} />;
-      default: return <Activity size={16} />;
-    }
-  };
 
   return (
     <div className="space-y-6">


### PR DESCRIPTION
## Summary
- ParamedicDashboard 미사용 state/함수/import 제거, export명 통일
- InfoCard에 React 타입 import 추가
- App.tsx에서 6개 페이지를 React.lazy로 동적 import + Suspense 적용
- PatientRequest import 경로 오류 수정

Closes #14

## Test plan
- [ ] 빌드 정상 확인
- [ ] 페이지 전환 시 로딩 표시 후 정상 렌더링 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)