### PR TITLE
fix: update state handlers to reflect changes in local state

### DIFF
--- a/src/components/hospital/BedManagement.tsx
+++ b/src/components/hospital/BedManagement.tsx
@@ -130,7 +130,7 @@ const mockBeds: BedInfo[] = [
 
 
 export function BedManagement() {
-  const [beds] = useState<BedInfo[]>(mockBeds);
+  const [beds, setBeds] = useState<BedInfo[]>(mockBeds);
   const [selectedSection, setSelectedSection] = useState<string>('all');
   const [selectedStatus, setSelectedStatus] = useState<string>('all');
   const [selectedBed, setSelectedBed] = useState<BedInfo | null>(null);
@@ -152,6 +152,7 @@ export function BedManagement() {
   };
 
   const handleBedStatusChange = (bedId: string, newStatus: string) => {
+    setBeds(prev => prev.map(b => b.id === bedId ? { ...b, status: newStatus as BedInfo['status'] } : b));
     toast.success(`병상 ${bedId}의 상태가 ${getBedStatusText(newStatus)}로 변경되었습니다.`);
   };
 

--- a/src/components/hospital/EquipmentStatus.tsx
+++ b/src/components/hospital/EquipmentStatus.tsx
@@ -164,7 +164,7 @@ const getTypeIcon = (type: string) => {
 };
 
 export function EquipmentStatus() {
-  const [equipment] = useState<Equipment[]>(mockEquipment);
+  const [equipment, setEquipment] = useState<Equipment[]>(mockEquipment);
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedType, setSelectedType] = useState<string>('all');
   const [selectedStatus, setSelectedStatus] = useState<string>('all');
@@ -197,6 +197,7 @@ export function EquipmentStatus() {
   };
 
   const handleStatusChange = (equipmentId: string, newStatus: string) => {
+    setEquipment(prev => prev.map(e => e.id === equipmentId ? { ...e, status: newStatus as Equipment['status'] } : e));
     toast.success(`장비 ${equipmentId}의 상태가 ${getEquipmentStatusText(newStatus)}로 변경되었습니다.`);
   };
 

--- a/src/components/hospital/PatientDetails.tsx
+++ b/src/components/hospital/PatientDetails.tsx
@@ -115,7 +115,7 @@ const mockPatients: Patient[] = [
 
 
 export function PatientDetails() {
-  const [patients] = useState<Patient[]>(mockPatients);
+  const [patients, setPatients] = useState<Patient[]>(mockPatients);
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedPatient, setSelectedPatient] = useState<Patient | null>(null);
   const [filterSeverity, setFilterSeverity] = useState<string>('all');
@@ -140,6 +140,7 @@ export function PatientDetails() {
   };
 
   const handleUpdateStatus = (patientId: string, newStatus: string) => {
+    setPatients(prev => prev.map(p => p.id === patientId ? { ...p, status: newStatus as Patient['status'] } : p));
     toast.success(`환자 ${patientId}의 상태가 ${newStatus}로 업데이트되었습니다.`);
   };
 

--- a/src/components/hospital/StaffManagement.tsx
+++ b/src/components/hospital/StaffManagement.tsx
@@ -159,7 +159,7 @@ const getRoleIcon = (role: string) => {
 };
 
 export function StaffManagement() {
-  const [staff] = useState<StaffMember[]>(mockStaff);
+  const [staff, setStaff] = useState<StaffMember[]>(mockStaff);
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedRole, setSelectedRole] = useState<string>('all');
   const [selectedStatus, setSelectedStatus] = useState<string>('all');
@@ -192,10 +192,12 @@ export function StaffManagement() {
   };
 
   const handleStatusChange = (staffId: string, newStatus: string) => {
+    setStaff(prev => prev.map(s => s.id === staffId ? { ...s, status: newStatus as StaffMember['status'] } : s));
     toast.success(`직원 ${staffId}의 상태가 ${getStaffStatusText(newStatus)}로 변경되었습니다.`);
   };
 
   const handleEmergencyCall = (staffId: string) => {
+    setStaff(prev => prev.map(s => s.id === staffId ? { ...s, status: 'emergency' as StaffMember['status'] } : s));
     toast.success(`${staffId} 직원에게 응급호출이 발송되었습니다.`);
   };
 


### PR DESCRIPTION
## Summary
- 4개 병원 관리 컴포넌트의 상태 변경 핸들러에 setState 호출 추가
- StaffManagement, BedManagement, EquipmentStatus, PatientDetails 수정
- 응급호출 시 직원 상태도 'emergency'로 반영

Closes #3

## Test plan
- [ ] 각 페이지에서 상태 변경 후 UI 즉시 반영 확인
- [ ] 다이얼로그 닫힌 후에도 변경된 상태 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)