### PR TITLE
fix(ux): Korean theme labels, h1 styling, and StatChip fix

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -50,15 +50,15 @@ function ThemeToggle() {
       <DropdownMenuContent align="end">
         <DropdownMenuItem onClick={() => setTheme("light")}>
           <Sun size={16} className="mr-2" />
-          Light
+          밝게
         </DropdownMenuItem>
         <DropdownMenuItem onClick={() => setTheme("dark")}>
           <Moon size={16} className="mr-2" />
-          Dark
+          어둡게
         </DropdownMenuItem>
         <DropdownMenuItem onClick={() => setTheme("system")}>
           <Monitor size={16} className="mr-2" />
-          System
+          시스템
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/src/components/hospital/BedManagement.tsx
+++ b/src/components/hospital/BedManagement.tsx
@@ -170,7 +170,7 @@ export function BedManagement() {
       {/* 헤더 */}
       <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
         <div>
-          <h1>병상 관리</h1>
+          <h1 className="text-2xl font-bold tracking-tight">병상 관리</h1>
           <p className="text-muted-foreground">응급실 병상 현황을 실시간으로 관리합니다</p>
         </div>
       </div>

--- a/src/components/hospital/EquipmentStatus.tsx
+++ b/src/components/hospital/EquipmentStatus.tsx
@@ -211,7 +211,7 @@ export function EquipmentStatus() {
       {/* 헤더 */}
       <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
         <div>
-          <h1>장비 현황</h1>
+          <h1 className="text-2xl font-bold tracking-tight">장비 현황</h1>
           <p className="text-muted-foreground">응급실 의료 장비 상태를 실시간으로 모니터링합니다</p>
         </div>
         <Button onClick={handleAddEquipment} className="flex items-center gap-2">

--- a/src/components/hospital/PatientDetails.tsx
+++ b/src/components/hospital/PatientDetails.tsx
@@ -150,7 +150,7 @@ export function PatientDetails() {
       {/* 헤더 */}
       <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
         <div>
-          <h1>환자 관리</h1>
+          <h1 className="text-2xl font-bold tracking-tight">환자 관리</h1>
           <p className="text-muted-foreground">응급실 내 환자 정보를 관리합니다</p>
         </div>
         <Button onClick={handleAddPatient} className="flex items-center gap-2">

--- a/src/components/hospital/StaffManagement.tsx
+++ b/src/components/hospital/StaffManagement.tsx
@@ -208,7 +208,7 @@ export function StaffManagement() {
       {/* 헤더 */}
       <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
         <div>
-          <h1>직원 관리</h1>
+          <h1 className="text-2xl font-bold tracking-tight">직원 관리</h1>
           <p className="text-muted-foreground">응급실 직원 현황 및 근무 관리</p>
         </div>
         <Button onClick={handleAddStaff} className="flex items-center gap-2">

--- a/src/components/paramedic/ParamedicDashboard.tsx
+++ b/src/components/paramedic/ParamedicDashboard.tsx
@@ -4,7 +4,7 @@ import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
 import { Switch } from "../ui/switch";
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger } from "../ui/sheet";
-import { InfoCard, StatChip } from "../common/InfoCard";
+import { InfoCard } from "../common/InfoCard";
 import { MiniMapPlaceholder } from "../common/MiniMapPlaceholder";
 import { generateMockRequests, generateMockHospitals, MockHospital } from "../common/models";
 import {
@@ -188,7 +188,7 @@ function HospitalCard({ hospital }: { hospital: MockHospital }) {
           </div>
           <div className="flex gap-1 mt-2">
             {hospital.specialties.slice(0, 3).map((specialty, i) => (
-              <StatChip key={i} label={specialty} value={0} size="sm" />
+              <Badge key={i} variant="outline" className="text-xs">{specialty}</Badge>
             ))}
           </div>
         </div>

--- a/src/components/paramedic/PatientRequest.tsx
+++ b/src/components/paramedic/PatientRequest.tsx
@@ -146,7 +146,7 @@ export function PatientRequest() {
             <Ambulance size={24} />
           </div>
           <div>
-            <h1>구급대원 환자 요청</h1>
+            <h1 className="text-2xl font-bold tracking-tight">구급대원 환자 요청</h1>
             <p className="text-muted-foreground">환자 정보를 선택하고 병원에 요청하세요</p>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- 테마 메뉴 한국어화 (밝게/어둡게/시스템)
- 5개 페이지의 h1에 일관된 Tailwind 스타일 적용
- ParamedicDashboard StatChip value=0을 Badge 컴포넌트로 교체

Closes #10

## Test plan
- [ ] 테마 드롭다운 한국어 표시 확인
- [ ] 각 페이지 제목 스타일 일관성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)