### PR TITLE
fix(a11y): add aria-labels, DialogDescription, and aria-live regions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,7 +41,7 @@ function ThemeToggle() {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="outline" size="sm">
+        <Button variant="outline" size="sm" aria-label="테마 변경">
           {theme === 'light' && <Sun size={16} />}
           {theme === 'dark' && <Moon size={16} />}
           {theme === 'system' && <Monitor size={16} />}
@@ -94,7 +94,7 @@ function AppContent() {
               </div>
               
               {/* Navigation */}
-              <nav className="hidden md:flex items-center gap-2 ml-8">
+              <nav aria-label="메인 메뉴" className="hidden md:flex items-center gap-2 ml-8">
                 {navigationItems.map((item) => {
                   const Icon = item.icon;
                   return (
@@ -117,7 +117,7 @@ function AppContent() {
           
           {/* Mobile Navigation */}
           <div className="md:hidden mt-3">
-            <div className="flex gap-1 overflow-x-auto">
+            <nav aria-label="모바일 메뉴" className="flex gap-1 overflow-x-auto">
               {navigationItems.map((item) => {
                 const Icon = item.icon;
                 return (
@@ -133,7 +133,7 @@ function AppContent() {
                   </Button>
                 );
               })}
-            </div>
+            </nav>
           </div>
         </div>
       </div>

--- a/src/components/hospital/BedManagement.tsx
+++ b/src/components/hospital/BedManagement.tsx
@@ -3,7 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
 import { Button } from "../ui/button";
 import { Badge } from "../ui/badge";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../ui/select";
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "../ui/dialog";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "../ui/dialog";
 import { Label } from "../ui/label";
 import { Input } from "../ui/input";
 import { Textarea } from "../ui/textarea";
@@ -334,6 +334,7 @@ export function BedManagement() {
             <>
               <DialogHeader>
                 <DialogTitle>병상 {selectedBed.id} 관리</DialogTitle>
+                <DialogDescription>병상 상태를 관리합니다.</DialogDescription>
               </DialogHeader>
               <div className="space-y-4">
                 <div>

--- a/src/components/hospital/EquipmentStatus.tsx
+++ b/src/components/hospital/EquipmentStatus.tsx
@@ -4,7 +4,7 @@ import { Button } from "../ui/button";
 import { Badge } from "../ui/badge";
 import { Input } from "../ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../ui/select";
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "../ui/dialog";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "../ui/dialog";
 import { Label } from "../ui/label";
 import { Textarea } from "../ui/textarea";
 import { Progress } from "../ui/progress";
@@ -417,6 +417,7 @@ export function EquipmentStatus() {
             <>
               <DialogHeader>
                 <DialogTitle>장비 관리 - {selectedEquipment.name}</DialogTitle>
+                <DialogDescription>장비 상태를 관리합니다.</DialogDescription>
               </DialogHeader>
               <div className="space-y-4">
                 <div className="grid grid-cols-2 gap-4">

--- a/src/components/hospital/HospitalDashboard.tsx
+++ b/src/components/hospital/HospitalDashboard.tsx
@@ -105,9 +105,10 @@ export function HospitalDashboard() {
             <span className={`text-sm ${accepting ? 'text-green-600' : 'text-red-600'}`}>
               {accepting ? '환자수용중' : '수용중단'}
             </span>
-            <Switch 
-              checked={accepting} 
+            <Switch
+              checked={accepting}
               onCheckedChange={handleAcceptingToggle}
+              aria-label="환자 수용 상태 전환"
             />
           </div>
         </div>
@@ -208,16 +209,18 @@ export function HospitalDashboard() {
                       <TableCell>
                         <div className="flex gap-2">
                           <RequestDetailDialog request={request} />
-                          <Button 
-                            size="sm" 
+                          <Button
+                            size="sm"
                             onClick={() => handleRequestAction(request.id, 'accept')}
+                            aria-label="수락"
                           >
                             <Check size={14} />
                           </Button>
-                          <Button 
-                            size="sm" 
+                          <Button
+                            size="sm"
                             variant="outline"
                             onClick={() => handleRequestAction(request.id, 'hold')}
+                            aria-label="보류"
                           >
                             <Pause size={14} />
                           </Button>
@@ -238,7 +241,7 @@ export function HospitalDashboard() {
             <CardHeader>
               <CardTitle>실시간 알림</CardTitle>
             </CardHeader>
-            <CardContent className="space-y-2">
+            <CardContent className="space-y-2" aria-live="polite">
               {recentAlerts.map((alert, index) => (
                 <div key={index} className="p-2 rounded bg-muted/50">
                   <p className="text-sm">{alert.message}</p>
@@ -303,7 +306,7 @@ function RequestDetailDialog({ request }: { request: MockRequest }) {
   return (
     <Dialog>
       <DialogTrigger asChild>
-        <Button size="sm" variant="outline">
+        <Button size="sm" variant="outline" aria-label="상세보기">
           <Eye size={14} />
         </Button>
       </DialogTrigger>

--- a/src/components/hospital/PatientDetails.tsx
+++ b/src/components/hospital/PatientDetails.tsx
@@ -5,7 +5,7 @@ import { Badge } from "../ui/badge";
 import { Input } from "../ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../ui/select";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../ui/table";
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "../ui/dialog";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "../ui/dialog";
 import { Label } from "../ui/label";
 import { Textarea } from "../ui/textarea";
 import { toast } from "sonner";
@@ -247,7 +247,7 @@ export function PatientDetails() {
                     </TableCell>
                     <TableCell>
                       <div className="flex gap-1">
-                        <Button variant="ghost" size="sm" onClick={() => { handleViewDetails(patient); setDialogOpen(true); }}>
+                        <Button variant="ghost" size="sm" onClick={() => { handleViewDetails(patient); setDialogOpen(true); }} aria-label="상세보기">
                           <Eye size={14} />
                         </Button>
                         <Button variant="ghost" size="sm" onClick={() => toast.success("환자 정보 수정 폼이 열렸습니다.")}>
@@ -269,6 +269,7 @@ export function PatientDetails() {
             <>
               <DialogHeader>
                 <DialogTitle>환자 상세 정보 - {selectedPatient.name}</DialogTitle>
+                <DialogDescription>환자 상세 정보입니다.</DialogDescription>
               </DialogHeader>
               <div className="space-y-6">
                 <div className="grid grid-cols-2 gap-4">

--- a/src/components/hospital/StaffManagement.tsx
+++ b/src/components/hospital/StaffManagement.tsx
@@ -5,7 +5,7 @@ import { Badge } from "../ui/badge";
 import { Input } from "../ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../ui/select";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../ui/table";
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "../ui/dialog";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "../ui/dialog";
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger } from "../ui/alert-dialog";
 import { Label } from "../ui/label";
 import { Avatar, AvatarFallback } from "../ui/avatar";
@@ -385,7 +385,7 @@ export function StaffManagement() {
                       </TableCell>
                       <TableCell>
                         <div className="flex gap-1">
-                          <Button variant="ghost" size="sm" onClick={() => { handleViewDetails(member); setDialogOpen(true); }}>
+                          <Button variant="ghost" size="sm" onClick={() => { handleViewDetails(member); setDialogOpen(true); }} aria-label="상세보기">
                             <Eye size={14} />
                           </Button>
                           <Button variant="ghost" size="sm" onClick={() => toast.success("직원 정보 수정 폼이 열렸습니다.")}>
@@ -429,6 +429,7 @@ export function StaffManagement() {
             <>
               <DialogHeader>
                 <DialogTitle>직원 상세 정보 - {selectedStaff.name}</DialogTitle>
+                <DialogDescription>직원 상세 정보입니다.</DialogDescription>
               </DialogHeader>
               <div className="space-y-6">
                 <div className="grid grid-cols-2 gap-4">

--- a/src/components/paramedic/ParamedicDashboard.tsx
+++ b/src/components/paramedic/ParamedicDashboard.tsx
@@ -155,7 +155,7 @@ export function ParamedicDashboard() {
             실시간 알림
           </CardTitle>
         </CardHeader>
-        <CardContent>
+        <CardContent aria-live="polite">
           <div className="space-y-2">
             {recentEvents.map((event, index) => (
               <div key={index} className="flex items-center justify-between p-2 rounded bg-muted/50">


### PR DESCRIPTION
## Summary
- 7개 파일에 접근성 속성 추가
- 아이콘 전용 버튼에 aria-label, Switch에 aria-label
- 4개 Dialog에 DialogDescription 추가
- 실시간 알림 영역에 aria-live="polite"
- 모바일 nav를 시맨틱 nav 요소로 변경

Closes #6

## Test plan
- [ ] 스크린 리더로 버튼/Switch 레이블 읽힘 확인
- [ ] Dialog 열 때 접근성 경고 사라짐 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)