### PR TITLE
fix(a11y): add visual status indicators and keyboard-accessible triggers

### DIFF
--- a/src/components/hospital/BedManagement.tsx
+++ b/src/components/hospital/BedManagement.tsx
@@ -180,6 +180,7 @@ export function BedManagement() {
         <Card>
           <CardContent className="pt-4">
             <div className="text-center">
+              <Bed className="mx-auto mb-2 text-muted-foreground" size={20} />
               <p className="text-sm text-muted-foreground">전체 병상</p>
               <p className="text-2xl font-bold">{bedStats.total}</p>
             </div>
@@ -188,6 +189,7 @@ export function BedManagement() {
         <Card>
           <CardContent className="pt-4">
             <div className="text-center">
+              <User className="mx-auto mb-2 text-red-600" size={20} />
               <p className="text-sm text-muted-foreground">사용중</p>
               <p className="text-2xl font-bold text-red-600">{bedStats.occupied}</p>
             </div>
@@ -196,6 +198,7 @@ export function BedManagement() {
         <Card>
           <CardContent className="pt-4">
             <div className="text-center">
+              <Plus className="mx-auto mb-2 text-green-600" size={20} />
               <p className="text-sm text-muted-foreground">사용가능</p>
               <p className="text-2xl font-bold text-green-600">{bedStats.available}</p>
             </div>
@@ -204,6 +207,7 @@ export function BedManagement() {
         <Card>
           <CardContent className="pt-4">
             <div className="text-center">
+              <Settings className="mx-auto mb-2 text-yellow-600" size={20} />
               <p className="text-sm text-muted-foreground">점검중</p>
               <p className="text-2xl font-bold text-yellow-600">{bedStats.maintenance}</p>
             </div>
@@ -212,6 +216,7 @@ export function BedManagement() {
         <Card>
           <CardContent className="pt-4">
             <div className="text-center">
+              <Clock className="mx-auto mb-2 text-blue-600" size={20} />
               <p className="text-sm text-muted-foreground">청소중</p>
               <p className="text-2xl font-bold text-blue-600">{bedStats.cleaning}</p>
             </div>
@@ -253,11 +258,11 @@ export function BedManagement() {
       {/* 병상 그리드 */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
         {filteredBeds.map((bed) => (
-          <Card key={bed.id} className={`cursor-pointer transition-all hover:shadow-md ${
-            bed.status === 'occupied' ? 'border-red-200' :
-            bed.status === 'available' ? 'border-green-200' :
-            bed.status === 'maintenance' ? 'border-yellow-200' :
-            'border-blue-200'
+          <Card key={bed.id} className={`cursor-pointer transition-all hover:shadow-md border-l-4 ${
+            bed.status === 'occupied' ? 'border-l-red-500' :
+            bed.status === 'available' ? 'border-l-green-500' :
+            bed.status === 'maintenance' ? 'border-l-yellow-500' :
+            'border-l-blue-500'
           }`}>
             <CardHeader className="pb-3">
               <div className="flex items-center justify-between">

--- a/src/components/hospital/EquipmentStatus.tsx
+++ b/src/components/hospital/EquipmentStatus.tsx
@@ -318,11 +318,11 @@ export function EquipmentStatus() {
         {filteredEquipment.map((item) => {
           const TypeIcon = getTypeIcon(item.type);
           return (
-            <Card key={item.id} className={`cursor-pointer transition-all hover:shadow-md ${
-              item.status === 'error' ? 'border-red-200' :
-              item.status === 'operational' ? 'border-green-200' :
-              item.status === 'maintenance' ? 'border-yellow-200' :
-              'border-gray-200'
+            <Card key={item.id} className={`cursor-pointer transition-all hover:shadow-md border-l-4 ${
+              item.status === 'error' ? 'border-l-red-500' :
+              item.status === 'operational' ? 'border-l-green-500' :
+              item.status === 'maintenance' ? 'border-l-yellow-500' :
+              'border-l-gray-500'
             }`}>
               <CardHeader className="pb-3">
                 <div className="flex items-center justify-between">

--- a/src/components/hospital/StaffManagement.tsx
+++ b/src/components/hospital/StaffManagement.tsx
@@ -149,6 +149,16 @@ const mockStaff: StaffMember[] = [
 ];
 
 
+const getStaffStatusIcon = (status: string) => {
+  switch (status) {
+    case 'on-duty': return '\u25CF'; // ●
+    case 'break': return '\u25CB';   // ○
+    case 'off-duty': return '\u2014'; // —
+    case 'emergency': return '\u26A0'; // ⚠
+    default: return '';
+  }
+};
+
 const getRoleIcon = (role: string) => {
   switch (role) {
     case 'doctor': return Stethoscope;
@@ -367,9 +377,12 @@ export function StaffManagement() {
                         </div>
                       </TableCell>
                       <TableCell>
-                        <Badge variant={getStaffStatusColor(member.status)}>
-                          {getStaffStatusText(member.status)}
-                        </Badge>
+                        <div className="flex items-center gap-1">
+                          <span aria-hidden="true">{getStaffStatusIcon(member.status)}</span>
+                          <Badge variant={getStaffStatusColor(member.status)}>
+                            {getStaffStatusText(member.status)}
+                          </Badge>
+                        </div>
                       </TableCell>
                       <TableCell>
                         <div className="space-y-1">

--- a/src/components/paramedic/ParamedicDashboard.tsx
+++ b/src/components/paramedic/ParamedicDashboard.tsx
@@ -174,7 +174,7 @@ function HospitalCard({ hospital }: { hospital: MockHospital }) {
   return (
     <Sheet>
       <SheetTrigger asChild>
-        <div className="p-3 border rounded-lg hover:bg-muted/50 cursor-pointer transition-colors">
+        <button className="w-full text-left p-3 border rounded-lg hover:bg-muted/50 cursor-pointer transition-colors">
           <div className="flex items-center justify-between mb-2">
             <h4 className="font-medium text-sm">{hospital.name}</h4>
             <Badge variant={hospital.accepting ? "default" : "destructive"}>
@@ -191,7 +191,7 @@ function HospitalCard({ hospital }: { hospital: MockHospital }) {
               <Badge key={i} variant="outline" className="text-xs">{specialty}</Badge>
             ))}
           </div>
-        </div>
+        </button>
       </SheetTrigger>
       <SheetContent>
         <SheetHeader>


### PR DESCRIPTION
## Summary
- 병상/장비 카드에 border-l-4 고채도 좌측 테두리 적용
- 병상 통계에 아이콘 추가, 직원 상태에 유니코드 심볼 추가
- ParamedicDashboard 병원 카드 div→button으로 키보드 접근 가능

Closes #7

## Test plan
- [ ] 색맹 시뮬레이터에서 상태 구분 가능 확인
- [ ] Tab 키로 병원 카드 포커스/Enter 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)