### PR TITLE
fix(ux): add empty state UI for filtered lists and tables

### DIFF
--- a/src/components/hospital/BedManagement.tsx
+++ b/src/components/hospital/BedManagement.tsx
@@ -256,6 +256,12 @@ export function BedManagement() {
       </Card>
 
       {/* 병상 그리드 */}
+      {filteredBeds.length === 0 ? (
+        <div className="flex flex-col items-center justify-center py-12 text-muted-foreground">
+          <p className="text-lg font-medium">검색 결과가 없습니다</p>
+          <p className="text-sm mt-1">필터 조건을 변경해 보세요</p>
+        </div>
+      ) : (
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
         {filteredBeds.map((bed) => (
           <Card key={bed.id} className={`cursor-pointer transition-all hover:shadow-md border-l-4 ${
@@ -332,6 +338,7 @@ export function BedManagement() {
           </Card>
         ))}
       </div>
+      )}
 
       <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
         <DialogContent>

--- a/src/components/hospital/EquipmentStatus.tsx
+++ b/src/components/hospital/EquipmentStatus.tsx
@@ -314,6 +314,12 @@ export function EquipmentStatus() {
       </Card>
 
       {/* 장비 그리드 */}
+      {filteredEquipment.length === 0 ? (
+        <div className="flex flex-col items-center justify-center py-12 text-muted-foreground">
+          <p className="text-lg font-medium">검색 결과가 없습니다</p>
+          <p className="text-sm mt-1">필터 조건을 변경해 보세요</p>
+        </div>
+      ) : (
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
         {filteredEquipment.map((item) => {
           const TypeIcon = getTypeIcon(item.type);
@@ -410,6 +416,7 @@ export function EquipmentStatus() {
           );
         })}
       </div>
+      )}
 
       <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
         <DialogContent className="max-w-2xl">

--- a/src/components/hospital/HospitalDashboard.tsx
+++ b/src/components/hospital/HospitalDashboard.tsx
@@ -189,45 +189,56 @@ export function HospitalDashboard() {
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {filteredRequests.slice(0, 6).map((request) => (
-                    <TableRow key={request.id}>
-                      <TableCell>{request.time.toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' })}</TableCell>
-                      <TableCell>
-                        <Badge variant={getSeverityColor(request.severity)}>
-                          {getSeverityLabel(request.severity)} ({request.severity})
-                        </Badge>
-                      </TableCell>
-                      <TableCell>
-                        {request.distanceKm}km / {request.eta}분
-                      </TableCell>
-                      <TableCell>
-                        <div className="flex items-center gap-2">
-                          {getSymptomIcon(request.symptom)}
-                          {request.symptom}
-                        </div>
-                      </TableCell>
-                      <TableCell>
-                        <div className="flex gap-2">
-                          <RequestDetailDialog request={request} />
-                          <Button
-                            size="sm"
-                            onClick={() => handleRequestAction(request.id, 'accept')}
-                            aria-label="수락"
-                          >
-                            <Check size={14} />
-                          </Button>
-                          <Button
-                            size="sm"
-                            variant="outline"
-                            onClick={() => handleRequestAction(request.id, 'hold')}
-                            aria-label="보류"
-                          >
-                            <Pause size={14} />
-                          </Button>
+                  {filteredRequests.length === 0 ? (
+                    <TableRow>
+                      <TableCell colSpan={5}>
+                        <div className="flex flex-col items-center justify-center py-12 text-muted-foreground">
+                          <p className="text-lg font-medium">검색 결과가 없습니다</p>
+                          <p className="text-sm mt-1">필터 조건을 변경해 보세요</p>
                         </div>
                       </TableCell>
                     </TableRow>
-                  ))}
+                  ) : (
+                    filteredRequests.slice(0, 6).map((request) => (
+                      <TableRow key={request.id}>
+                        <TableCell>{request.time.toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' })}</TableCell>
+                        <TableCell>
+                          <Badge variant={getSeverityColor(request.severity)}>
+                            {getSeverityLabel(request.severity)} ({request.severity})
+                          </Badge>
+                        </TableCell>
+                        <TableCell>
+                          {request.distanceKm}km / {request.eta}분
+                        </TableCell>
+                        <TableCell>
+                          <div className="flex items-center gap-2">
+                            {getSymptomIcon(request.symptom)}
+                            {request.symptom}
+                          </div>
+                        </TableCell>
+                        <TableCell>
+                          <div className="flex gap-2">
+                            <RequestDetailDialog request={request} />
+                            <Button
+                              size="sm"
+                              onClick={() => handleRequestAction(request.id, 'accept')}
+                              aria-label="수락"
+                            >
+                              <Check size={14} />
+                            </Button>
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              onClick={() => handleRequestAction(request.id, 'hold')}
+                              aria-label="보류"
+                            >
+                              <Pause size={14} />
+                            </Button>
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    ))
+                  )}
                 </TableBody>
               </Table>
             </CardContent>

--- a/src/components/hospital/PatientDetails.tsx
+++ b/src/components/hospital/PatientDetails.tsx
@@ -224,39 +224,50 @@ export function PatientDetails() {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {filteredPatients.map((patient) => (
-                  <TableRow key={patient.id}>
-                    <TableCell>{patient.id}</TableCell>
-                    <TableCell>{patient.name}</TableCell>
-                    <TableCell>{patient.age}세 / {patient.gender}</TableCell>
-                    <TableCell>{patient.diagnosis}</TableCell>
-                    <TableCell>
-                      <Badge variant={getSeverityColor(patient.severity)}>
-                        {getSeverityText(patient.severity)}
-                      </Badge>
-                    </TableCell>
-                    <TableCell className="flex items-center gap-1">
-                      <Clock size={14} />
-                      {patient.admissionTime}
-                    </TableCell>
-                    <TableCell>{patient.bed}</TableCell>
-                    <TableCell>
-                      <Badge variant={getPatientStatusColor(patient.status)}>
-                        {getPatientStatusText(patient.status)}
-                      </Badge>
-                    </TableCell>
-                    <TableCell>
-                      <div className="flex gap-1">
-                        <Button variant="ghost" size="sm" onClick={() => { handleViewDetails(patient); setDialogOpen(true); }} aria-label="상세보기">
-                          <Eye size={14} />
-                        </Button>
-                        <Button variant="ghost" size="sm" onClick={() => toast.success("환자 정보 수정 폼이 열렸습니다.")}>
-                          <Edit size={14} />
-                        </Button>
+                {filteredPatients.length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={9}>
+                      <div className="flex flex-col items-center justify-center py-12 text-muted-foreground">
+                        <p className="text-lg font-medium">검색 결과가 없습니다</p>
+                        <p className="text-sm mt-1">필터 조건을 변경해 보세요</p>
                       </div>
                     </TableCell>
                   </TableRow>
-                ))}
+                ) : (
+                  filteredPatients.map((patient) => (
+                    <TableRow key={patient.id}>
+                      <TableCell>{patient.id}</TableCell>
+                      <TableCell>{patient.name}</TableCell>
+                      <TableCell>{patient.age}세 / {patient.gender}</TableCell>
+                      <TableCell>{patient.diagnosis}</TableCell>
+                      <TableCell>
+                        <Badge variant={getSeverityColor(patient.severity)}>
+                          {getSeverityText(patient.severity)}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="flex items-center gap-1">
+                        <Clock size={14} />
+                        {patient.admissionTime}
+                      </TableCell>
+                      <TableCell>{patient.bed}</TableCell>
+                      <TableCell>
+                        <Badge variant={getPatientStatusColor(patient.status)}>
+                          {getPatientStatusText(patient.status)}
+                        </Badge>
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex gap-1">
+                          <Button variant="ghost" size="sm" onClick={() => { handleViewDetails(patient); setDialogOpen(true); }} aria-label="상세보기">
+                            <Eye size={14} />
+                          </Button>
+                          <Button variant="ghost" size="sm" onClick={() => toast.success("환자 정보 수정 폼이 열렸습니다.")}>
+                            <Edit size={14} />
+                          </Button>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  ))
+                )}
               </TableBody>
             </Table>
           </div>

--- a/src/components/hospital/StaffManagement.tsx
+++ b/src/components/hospital/StaffManagement.tsx
@@ -341,95 +341,106 @@ export function StaffManagement() {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {filteredStaff.map((member) => {
-                  const RoleIcon = getRoleIcon(member.role);
-                  return (
-                    <TableRow key={member.id}>
-                      <TableCell>
-                        <div className="flex items-center gap-3">
-                          <Avatar>
-                            <AvatarFallback>
-                              <RoleIcon size={16} />
-                            </AvatarFallback>
-                          </Avatar>
-                          <div>
-                            <p className="font-medium">{member.name}</p>
-                            <p className="text-sm text-muted-foreground">{member.id}</p>
+                {filteredStaff.length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={8}>
+                      <div className="flex flex-col items-center justify-center py-12 text-muted-foreground">
+                        <p className="text-lg font-medium">검색 결과가 없습니다</p>
+                        <p className="text-sm mt-1">필터 조건을 변경해 보세요</p>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  filteredStaff.map((member) => {
+                    const RoleIcon = getRoleIcon(member.role);
+                    return (
+                      <TableRow key={member.id}>
+                        <TableCell>
+                          <div className="flex items-center gap-3">
+                            <Avatar>
+                              <AvatarFallback>
+                                <RoleIcon size={16} />
+                              </AvatarFallback>
+                            </Avatar>
+                            <div>
+                              <p className="font-medium">{member.name}</p>
+                              <p className="text-sm text-muted-foreground">{member.id}</p>
+                            </div>
                           </div>
-                        </div>
-                      </TableCell>
-                      <TableCell>
-                        <Badge variant={getRoleColor(member.role)}>
-                          {getRoleText(member.role)}
-                        </Badge>
-                      </TableCell>
-                      <TableCell>{member.department}</TableCell>
-                      <TableCell>
-                        <div className="text-sm">
-                          <p>{member.shiftStart} - {member.shiftEnd}</p>
-                          <p className="text-muted-foreground">{member.shift === 'day' ? '주간' : member.shift === 'night' ? '야간' : '저녁'}근무</p>
-                        </div>
-                      </TableCell>
-                      <TableCell>
-                        <div className="flex items-center gap-1">
-                          <MapPin size={14} className="text-muted-foreground" />
-                          {member.currentLocation}
-                        </div>
-                      </TableCell>
-                      <TableCell>
-                        <div className="flex items-center gap-1">
-                          <span aria-hidden="true">{getStaffStatusIcon(member.status)}</span>
-                          <Badge variant={getStaffStatusColor(member.status)}>
-                            {getStaffStatusText(member.status)}
+                        </TableCell>
+                        <TableCell>
+                          <Badge variant={getRoleColor(member.role)}>
+                            {getRoleText(member.role)}
                           </Badge>
-                        </div>
-                      </TableCell>
-                      <TableCell>
-                        <div className="space-y-1">
-                          <div className="flex items-center gap-1 text-sm">
-                            <Phone size={12} />
-                            {member.phone}
+                        </TableCell>
+                        <TableCell>{member.department}</TableCell>
+                        <TableCell>
+                          <div className="text-sm">
+                            <p>{member.shiftStart} - {member.shiftEnd}</p>
+                            <p className="text-muted-foreground">{member.shift === 'day' ? '주간' : member.shift === 'night' ? '야간' : '저녁'}근무</p>
                           </div>
-                          <div className="flex items-center gap-1 text-sm text-muted-foreground">
-                            <Mail size={12} />
-                            {member.email}
+                        </TableCell>
+                        <TableCell>
+                          <div className="flex items-center gap-1">
+                            <MapPin size={14} className="text-muted-foreground" />
+                            {member.currentLocation}
                           </div>
-                        </div>
-                      </TableCell>
-                      <TableCell>
-                        <div className="flex gap-1">
-                          <Button variant="ghost" size="sm" onClick={() => { handleViewDetails(member); setDialogOpen(true); }} aria-label="상세보기">
-                            <Eye size={14} />
-                          </Button>
-                          <Button variant="ghost" size="sm" onClick={() => toast.success("직원 정보 수정 폼이 열렸습니다.")}>
-                            <Edit size={14} />
-                          </Button>
-                          <AlertDialog>
-                            <AlertDialogTrigger asChild>
-                              <Button variant="destructive" size="sm" aria-label="응급호출">
-                                <Shield size={14} />
-                              </Button>
-                            </AlertDialogTrigger>
-                            <AlertDialogContent>
-                              <AlertDialogHeader>
-                                <AlertDialogTitle>응급호출 확인</AlertDialogTitle>
-                                <AlertDialogDescription>
-                                  {member.name}에게 응급호출을 발송하시겠습니까? 이 작업은 취소할 수 없습니다.
-                                </AlertDialogDescription>
-                              </AlertDialogHeader>
-                              <AlertDialogFooter>
-                                <AlertDialogCancel>취소</AlertDialogCancel>
-                                <AlertDialogAction onClick={() => handleEmergencyCall(member.id)}>
-                                  호출 발송
-                                </AlertDialogAction>
-                              </AlertDialogFooter>
-                            </AlertDialogContent>
-                          </AlertDialog>
-                        </div>
-                      </TableCell>
-                    </TableRow>
-                  );
-                })}
+                        </TableCell>
+                        <TableCell>
+                          <div className="flex items-center gap-1">
+                            <span aria-hidden="true">{getStaffStatusIcon(member.status)}</span>
+                            <Badge variant={getStaffStatusColor(member.status)}>
+                              {getStaffStatusText(member.status)}
+                            </Badge>
+                          </div>
+                        </TableCell>
+                        <TableCell>
+                          <div className="space-y-1">
+                            <div className="flex items-center gap-1 text-sm">
+                              <Phone size={12} />
+                              {member.phone}
+                            </div>
+                            <div className="flex items-center gap-1 text-sm text-muted-foreground">
+                              <Mail size={12} />
+                              {member.email}
+                            </div>
+                          </div>
+                        </TableCell>
+                        <TableCell>
+                          <div className="flex gap-1">
+                            <Button variant="ghost" size="sm" onClick={() => { handleViewDetails(member); setDialogOpen(true); }} aria-label="상세보기">
+                              <Eye size={14} />
+                            </Button>
+                            <Button variant="ghost" size="sm" onClick={() => toast.success("직원 정보 수정 폼이 열렸습니다.")}>
+                              <Edit size={14} />
+                            </Button>
+                            <AlertDialog>
+                              <AlertDialogTrigger asChild>
+                                <Button variant="destructive" size="sm" aria-label="응급호출">
+                                  <Shield size={14} />
+                                </Button>
+                              </AlertDialogTrigger>
+                              <AlertDialogContent>
+                                <AlertDialogHeader>
+                                  <AlertDialogTitle>응급호출 확인</AlertDialogTitle>
+                                  <AlertDialogDescription>
+                                    {member.name}에게 응급호출을 발송하시겠습니까? 이 작업은 취소할 수 없습니다.
+                                  </AlertDialogDescription>
+                                </AlertDialogHeader>
+                                <AlertDialogFooter>
+                                  <AlertDialogCancel>취소</AlertDialogCancel>
+                                  <AlertDialogAction onClick={() => handleEmergencyCall(member.id)}>
+                                    호출 발송
+                                  </AlertDialogAction>
+                                </AlertDialogFooter>
+                              </AlertDialogContent>
+                            </AlertDialog>
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })
+                )}
               </TableBody>
             </Table>
           </div>


### PR DESCRIPTION
## Summary
- 5개 페이지에 검색/필터 결과 0건 시 빈 상태 메시지 추가
- 테이블: TableRow+TableCell colSpan으로 빈 상태 표시
- 그리드: 그리드 대신 빈 상태 div 표시

Closes #8

## Test plan
- [ ] 각 페이지에서 존재하지 않는 검색어 입력 시 빈 상태 UI 표시 확인
- [ ] 필터 변경 시 결과 복원 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)