### PR TITLE
refactor: extract mock data to dedicated mocks directory

### DIFF
--- a/src/components/hospital/BedManagement.tsx
+++ b/src/components/hospital/BedManagement.tsx
@@ -9,6 +9,7 @@ import { Input } from "../ui/input";
 import { Textarea } from "../ui/textarea";
 import { toast } from "sonner";
 import { getBedStatusColor, getBedStatusText } from "../../utils/statusHelpers";
+import { mockBeds, type BedInfo } from "@/mocks/bedData";
 import {
   Bed,
   Plus,
@@ -18,115 +19,6 @@ import {
   Calendar,
   Clock
 } from 'lucide-react';
-
-interface BedInfo {
-  id: string;
-  section: string;
-  number: string;
-  status: 'occupied' | 'available' | 'maintenance' | 'cleaning';
-  patient?: {
-    name: string;
-    id: string;
-    admissionTime: string;
-    diagnosis: string;
-  };
-  equipment: string[];
-  lastCleaned: string;
-  notes?: string;
-}
-
-const mockBeds: BedInfo[] = [
-  {
-    id: 'A-01',
-    section: 'A',
-    number: '01',
-    status: 'occupied',
-    patient: {
-      name: '김민수',
-      id: 'P001',
-      admissionTime: '14:25',
-      diagnosis: '급성 심근경색'
-    },
-    equipment: ['심전도', '산소공급', '링거'],
-    lastCleaned: '13:30',
-    notes: '중환자, 지속적인 모니터링 필요'
-  },
-  {
-    id: 'A-02',
-    section: 'A',
-    number: '02',
-    status: 'occupied',
-    patient: {
-      name: '박철수',
-      id: 'P003',
-      admissionTime: '12:30',
-      diagnosis: '호흡곤란'
-    },
-    equipment: ['산소공급', '호흡기'],
-    lastCleaned: '12:00',
-  },
-  {
-    id: 'A-03',
-    section: 'A',
-    number: '03',
-    status: 'available',
-    equipment: ['기본'],
-    lastCleaned: '15:00',
-  },
-  {
-    id: 'B-01',
-    section: 'B',
-    number: '01',
-    status: 'maintenance',
-    equipment: ['기본'],
-    lastCleaned: '10:00',
-    notes: '전기 시설 점검 중'
-  },
-  {
-    id: 'B-02',
-    section: 'B',
-    number: '02',
-    status: 'cleaning',
-    equipment: ['기본'],
-    lastCleaned: '진행중',
-  },
-  {
-    id: 'B-03',
-    section: 'B',
-    number: '03',
-    status: 'occupied',
-    patient: {
-      name: '이영희',
-      id: 'P002',
-      admissionTime: '13:45',
-      diagnosis: '골절 의심'
-    },
-    equipment: ['X-ray 호환'],
-    lastCleaned: '13:15',
-  },
-  {
-    id: 'C-01',
-    section: 'C',
-    number: '01',
-    status: 'occupied',
-    patient: {
-      name: '최미영',
-      id: 'P004',
-      admissionTime: '11:15',
-      diagnosis: '두통 및 어지러움'
-    },
-    equipment: ['기본'],
-    lastCleaned: '11:00',
-  },
-  {
-    id: 'C-02',
-    section: 'C',
-    number: '02',
-    status: 'available',
-    equipment: ['기본'],
-    lastCleaned: '14:30',
-  }
-];
 
 
 export function BedManagement() {

--- a/src/components/hospital/EquipmentStatus.tsx
+++ b/src/components/hospital/EquipmentStatus.tsx
@@ -10,6 +10,7 @@ import { Textarea } from "../ui/textarea";
 import { Progress } from "../ui/progress";
 import { toast } from "sonner";
 import { getEquipmentStatusColor, getEquipmentStatusText, getEquipmentTypeText } from "../../utils/statusHelpers";
+import { mockEquipment, type Equipment } from "@/mocks/equipmentData";
 import {
   Search,
   Plus,
@@ -28,128 +29,6 @@ import {
   Thermometer,
   Droplets
 } from 'lucide-react';
-
-interface Equipment {
-  id: string;
-  name: string;
-  type: 'monitor' | 'ventilator' | 'defibrillator' | 'xray' | 'ultrasound' | 'infusion' | 'other';
-  model: string;
-  manufacturer: string;
-  status: 'operational' | 'maintenance' | 'error' | 'offline';
-  location: string;
-  lastMaintenance: string;
-  nextMaintenance: string;
-  batteryLevel?: number;
-  usageHours: number;
-  alerts: string[];
-  assignedTo?: string;
-  notes?: string;
-}
-
-const mockEquipment: Equipment[] = [
-  {
-    id: 'EQ001',
-    name: '환자 모니터 #1',
-    type: 'monitor',
-    model: 'PhilipsX40',
-    manufacturer: 'Philips',
-    status: 'operational',
-    location: '응급실 A-01',
-    lastMaintenance: '2024-01-15',
-    nextMaintenance: '2024-04-15',
-    batteryLevel: 85,
-    usageHours: 1250,
-    alerts: [],
-    assignedTo: '김민수 (P001)'
-  },
-  {
-    id: 'EQ002',
-    name: '인공호흡기 #1',
-    type: 'ventilator',
-    model: 'DrägerV500',
-    manufacturer: 'Dräger',
-    status: 'operational',
-    location: '응급실 A-02',
-    lastMaintenance: '2024-02-01',
-    nextMaintenance: '2024-05-01',
-    batteryLevel: 92,
-    usageHours: 890,
-    alerts: [],
-    assignedTo: '박철수 (P003)'
-  },
-  {
-    id: 'EQ003',
-    name: '제세동기 #1',
-    type: 'defibrillator',
-    model: 'ZollR Plus',
-    manufacturer: 'Zoll',
-    status: 'maintenance',
-    location: '정비실',
-    lastMaintenance: '2024-02-20',
-    nextMaintenance: '2024-03-20',
-    batteryLevel: 100,
-    usageHours: 450,
-    alerts: ['정기 점검 중'],
-    notes: '전극 패드 교체 예정'
-  },
-  {
-    id: 'EQ004',
-    name: 'X-ray 촬영기',
-    type: 'xray',
-    model: 'SiemensArios',
-    manufacturer: 'Siemens',
-    status: 'operational',
-    location: '영상의학과',
-    lastMaintenance: '2024-01-10',
-    nextMaintenance: '2024-04-10',
-    usageHours: 2150,
-    alerts: []
-  },
-  {
-    id: 'EQ005',
-    name: '초음파 진단기',
-    type: 'ultrasound',
-    model: 'GELogiq',
-    manufacturer: 'GE Healthcare',
-    status: 'error',
-    location: '응급실 B구역',
-    lastMaintenance: '2024-01-25',
-    nextMaintenance: '2024-04-25',
-    usageHours: 1680,
-    alerts: ['프로브 연결 오류', '긴급 수리 필요'],
-    notes: '프로브 케이블 손상으로 인한 오류'
-  },
-  {
-    id: 'EQ006',
-    name: '수액 주입기 #1',
-    type: 'infusion',
-    model: 'B.BraunPerfusor',
-    manufacturer: 'B.Braun',
-    status: 'operational',
-    location: '응급실 B-03',
-    lastMaintenance: '2024-02-05',
-    nextMaintenance: '2024-05-05',
-    batteryLevel: 78,
-    usageHours: 820,
-    alerts: [],
-    assignedTo: '이영희 (P002)'
-  },
-  {
-    id: 'EQ007',
-    name: '환자 모니터 #2',
-    type: 'monitor',
-    model: 'PhilipsX40',
-    manufacturer: 'Philips',
-    status: 'offline',
-    location: '창고',
-    lastMaintenance: '2024-01-20',
-    nextMaintenance: '2024-04-20',
-    batteryLevel: 0,
-    usageHours: 2890,
-    alerts: ['배터리 방전', '전원 공급 필요'],
-    notes: '예비 장비로 보관 중'
-  }
-];
 
 const getTypeIcon = (type: string) => {
   switch (type) {

--- a/src/components/hospital/PatientDetails.tsx
+++ b/src/components/hospital/PatientDetails.tsx
@@ -10,6 +10,7 @@ import { Label } from "../ui/label";
 import { Textarea } from "../ui/textarea";
 import { toast } from "sonner";
 import { getSeverityColor, getSeverityText, getPatientStatusColor, getPatientStatusText } from "../../utils/statusHelpers";
+import { mockPatients, type Patient } from "@/mocks/patientData";
 import {
   Search,
   Plus,
@@ -23,95 +24,6 @@ import {
   Activity,
   Users
 } from 'lucide-react';
-
-interface Patient {
-  id: string;
-  name: string;
-  age: number;
-  gender: string;
-  diagnosis: string;
-  severity: 'critical' | 'urgent' | 'stable';
-  admissionTime: string;
-  bed: string;
-  vitals: {
-    heartRate: number;
-    bloodPressure: string;
-    temperature: number;
-    oxygenSaturation: number;
-  };
-  status: 'waiting' | 'treating' | 'stable' | 'discharged';
-}
-
-const mockPatients: Patient[] = [
-  {
-    id: 'P001',
-    name: '김민수',
-    age: 45,
-    gender: '남성',
-    diagnosis: '급성 심근경색',
-    severity: 'critical',
-    admissionTime: '14:25',
-    bed: 'A-01',
-    vitals: {
-      heartRate: 95,
-      bloodPressure: '140/90',
-      temperature: 37.2,
-      oxygenSaturation: 98
-    },
-    status: 'treating'
-  },
-  {
-    id: 'P002',
-    name: '이영희',
-    age: 32,
-    gender: '여성',
-    diagnosis: '골절 의심',
-    severity: 'urgent',
-    admissionTime: '13:45',
-    bed: 'B-03',
-    vitals: {
-      heartRate: 82,
-      bloodPressure: '120/80',
-      temperature: 36.8,
-      oxygenSaturation: 99
-    },
-    status: 'waiting'
-  },
-  {
-    id: 'P003',
-    name: '박철수',
-    age: 67,
-    gender: '남성',
-    diagnosis: '호흡곤란',
-    severity: 'urgent',
-    admissionTime: '12:30',
-    bed: 'A-02',
-    vitals: {
-      heartRate: 105,
-      bloodPressure: '160/95',
-      temperature: 38.1,
-      oxygenSaturation: 92
-    },
-    status: 'treating'
-  },
-  {
-    id: 'P004',
-    name: '최미영',
-    age: 28,
-    gender: '여성',
-    diagnosis: '두통 및 어지러움',
-    severity: 'stable',
-    admissionTime: '11:15',
-    bed: 'C-01',
-    vitals: {
-      heartRate: 75,
-      bloodPressure: '115/75',
-      temperature: 36.5,
-      oxygenSaturation: 100
-    },
-    status: 'stable'
-  }
-];
 
 
 export function PatientDetails() {

--- a/src/components/hospital/StaffManagement.tsx
+++ b/src/components/hospital/StaffManagement.tsx
@@ -11,6 +11,7 @@ import { Label } from "../ui/label";
 import { Avatar, AvatarFallback } from "../ui/avatar";
 import { toast } from "sonner";
 import { getRoleColor, getRoleText, getStaffStatusColor, getStaffStatusText } from "../../utils/statusHelpers";
+import { mockStaff, type StaffMember } from "@/mocks/staffData";
 import {
   Search,
   Plus,
@@ -27,126 +28,6 @@ import {
   Activity,
   Shield
 } from 'lucide-react';
-
-interface StaffMember {
-  id: string;
-  name: string;
-  role: 'doctor' | 'nurse' | 'technician' | 'admin';
-  department: string;
-  shift: 'day' | 'night' | 'evening';
-  status: 'on-duty' | 'off-duty' | 'break' | 'emergency';
-  phone: string;
-  email: string;
-  specialization?: string;
-  yearsOfExperience: number;
-  currentLocation: string;
-  shiftStart: string;
-  shiftEnd: string;
-  certifications: string[];
-  emergencyContact: string;
-}
-
-const mockStaff: StaffMember[] = [
-  {
-    id: 'DOC001',
-    name: '김의사',
-    role: 'doctor',
-    department: '응급의학과',
-    shift: 'day',
-    status: 'on-duty',
-    phone: '010-0000-0001',
-    email: 'staff1@example.com',
-    specialization: '외상외과',
-    yearsOfExperience: 8,
-    currentLocation: '응급실 A구역',
-    shiftStart: '08:00',
-    shiftEnd: '18:00',
-    certifications: ['ACLS', 'ATLS', 'BLS'],
-    emergencyContact: '010-0000-1001'
-  },
-  {
-    id: 'DOC002',
-    name: '이의사',
-    role: 'doctor',
-    department: '응급의학과',
-    shift: 'night',
-    status: 'off-duty',
-    phone: '010-0000-0002',
-    email: 'staff2@example.com',
-    specialization: '내과',
-    yearsOfExperience: 12,
-    currentLocation: '대기실',
-    shiftStart: '18:00',
-    shiftEnd: '08:00',
-    certifications: ['ACLS', 'BLS', 'PALS'],
-    emergencyContact: '010-0000-1002'
-  },
-  {
-    id: 'NUR001',
-    name: '박간호사',
-    role: 'nurse',
-    department: '응급실',
-    shift: 'day',
-    status: 'on-duty',
-    phone: '010-0000-0003',
-    email: 'staff3@example.com',
-    yearsOfExperience: 5,
-    currentLocation: '응급실 B구역',
-    shiftStart: '08:00',
-    shiftEnd: '18:00',
-    certifications: ['BLS', 'ACLS'],
-    emergencyContact: '010-0000-1003'
-  },
-  {
-    id: 'NUR002',
-    name: '최간호사',
-    role: 'nurse',
-    department: '응급실',
-    shift: 'evening',
-    status: 'break',
-    phone: '010-0000-0004',
-    email: 'staff4@example.com',
-    yearsOfExperience: 3,
-    currentLocation: '휴게실',
-    shiftStart: '14:00',
-    shiftEnd: '22:00',
-    certifications: ['BLS'],
-    emergencyContact: '010-0000-1004'
-  },
-  {
-    id: 'TEC001',
-    name: '정기사',
-    role: 'technician',
-    department: '방사선과',
-    shift: 'day',
-    status: 'on-duty',
-    phone: '010-0000-0005',
-    email: 'staff5@example.com',
-    specialization: 'X-ray, CT',
-    yearsOfExperience: 7,
-    currentLocation: '영상의학과',
-    shiftStart: '08:00',
-    shiftEnd: '18:00',
-    certifications: ['방사선사', 'CT 전문'],
-    emergencyContact: '010-0000-1005'
-  },
-  {
-    id: 'ADM001',
-    name: '송관리자',
-    role: 'admin',
-    department: '응급실 관리',
-    shift: 'day',
-    status: 'on-duty',
-    phone: '010-0000-0006',
-    email: 'staff6@example.com',
-    yearsOfExperience: 10,
-    currentLocation: '관리실',
-    shiftStart: '08:00',
-    shiftEnd: '18:00',
-    certifications: ['병원관리사'],
-    emergencyContact: '010-0000-1006'
-  }
-];
 
 
 const getStaffStatusIcon = (status: string) => {

--- a/src/mocks/bedData.ts
+++ b/src/mocks/bedData.ts
@@ -1,0 +1,108 @@
+export interface BedInfo {
+  id: string;
+  section: string;
+  number: string;
+  status: 'occupied' | 'available' | 'maintenance' | 'cleaning';
+  patient?: {
+    name: string;
+    id: string;
+    admissionTime: string;
+    diagnosis: string;
+  };
+  equipment: string[];
+  lastCleaned: string;
+  notes?: string;
+}
+
+export const mockBeds: BedInfo[] = [
+  {
+    id: 'A-01',
+    section: 'A',
+    number: '01',
+    status: 'occupied',
+    patient: {
+      name: '김민수',
+      id: 'P001',
+      admissionTime: '14:25',
+      diagnosis: '급성 심근경색'
+    },
+    equipment: ['심전도', '산소공급', '링거'],
+    lastCleaned: '13:30',
+    notes: '중환자, 지속적인 모니터링 필요'
+  },
+  {
+    id: 'A-02',
+    section: 'A',
+    number: '02',
+    status: 'occupied',
+    patient: {
+      name: '박철수',
+      id: 'P003',
+      admissionTime: '12:30',
+      diagnosis: '호흡곤란'
+    },
+    equipment: ['산소공급', '호흡기'],
+    lastCleaned: '12:00',
+  },
+  {
+    id: 'A-03',
+    section: 'A',
+    number: '03',
+    status: 'available',
+    equipment: ['기본'],
+    lastCleaned: '15:00',
+  },
+  {
+    id: 'B-01',
+    section: 'B',
+    number: '01',
+    status: 'maintenance',
+    equipment: ['기본'],
+    lastCleaned: '10:00',
+    notes: '전기 시설 점검 중'
+  },
+  {
+    id: 'B-02',
+    section: 'B',
+    number: '02',
+    status: 'cleaning',
+    equipment: ['기본'],
+    lastCleaned: '진행중',
+  },
+  {
+    id: 'B-03',
+    section: 'B',
+    number: '03',
+    status: 'occupied',
+    patient: {
+      name: '이영희',
+      id: 'P002',
+      admissionTime: '13:45',
+      diagnosis: '골절 의심'
+    },
+    equipment: ['X-ray 호환'],
+    lastCleaned: '13:15',
+  },
+  {
+    id: 'C-01',
+    section: 'C',
+    number: '01',
+    status: 'occupied',
+    patient: {
+      name: '최미영',
+      id: 'P004',
+      admissionTime: '11:15',
+      diagnosis: '두통 및 어지러움'
+    },
+    equipment: ['기본'],
+    lastCleaned: '11:00',
+  },
+  {
+    id: 'C-02',
+    section: 'C',
+    number: '02',
+    status: 'available',
+    equipment: ['기본'],
+    lastCleaned: '14:30',
+  }
+];

--- a/src/mocks/equipmentData.ts
+++ b/src/mocks/equipmentData.ts
@@ -1,0 +1,121 @@
+export interface Equipment {
+  id: string;
+  name: string;
+  type: 'monitor' | 'ventilator' | 'defibrillator' | 'xray' | 'ultrasound' | 'infusion' | 'other';
+  model: string;
+  manufacturer: string;
+  status: 'operational' | 'maintenance' | 'error' | 'offline';
+  location: string;
+  lastMaintenance: string;
+  nextMaintenance: string;
+  batteryLevel?: number;
+  usageHours: number;
+  alerts: string[];
+  assignedTo?: string;
+  notes?: string;
+}
+
+export const mockEquipment: Equipment[] = [
+  {
+    id: 'EQ001',
+    name: '환자 모니터 #1',
+    type: 'monitor',
+    model: 'PhilipsX40',
+    manufacturer: 'Philips',
+    status: 'operational',
+    location: '응급실 A-01',
+    lastMaintenance: '2024-01-15',
+    nextMaintenance: '2024-04-15',
+    batteryLevel: 85,
+    usageHours: 1250,
+    alerts: [],
+    assignedTo: '김민수 (P001)'
+  },
+  {
+    id: 'EQ002',
+    name: '인공호흡기 #1',
+    type: 'ventilator',
+    model: 'DrägerV500',
+    manufacturer: 'Dräger',
+    status: 'operational',
+    location: '응급실 A-02',
+    lastMaintenance: '2024-02-01',
+    nextMaintenance: '2024-05-01',
+    batteryLevel: 92,
+    usageHours: 890,
+    alerts: [],
+    assignedTo: '박철수 (P003)'
+  },
+  {
+    id: 'EQ003',
+    name: '제세동기 #1',
+    type: 'defibrillator',
+    model: 'ZollR Plus',
+    manufacturer: 'Zoll',
+    status: 'maintenance',
+    location: '정비실',
+    lastMaintenance: '2024-02-20',
+    nextMaintenance: '2024-03-20',
+    batteryLevel: 100,
+    usageHours: 450,
+    alerts: ['정기 점검 중'],
+    notes: '전극 패드 교체 예정'
+  },
+  {
+    id: 'EQ004',
+    name: 'X-ray 촬영기',
+    type: 'xray',
+    model: 'SiemensArios',
+    manufacturer: 'Siemens',
+    status: 'operational',
+    location: '영상의학과',
+    lastMaintenance: '2024-01-10',
+    nextMaintenance: '2024-04-10',
+    usageHours: 2150,
+    alerts: []
+  },
+  {
+    id: 'EQ005',
+    name: '초음파 진단기',
+    type: 'ultrasound',
+    model: 'GELogiq',
+    manufacturer: 'GE Healthcare',
+    status: 'error',
+    location: '응급실 B구역',
+    lastMaintenance: '2024-01-25',
+    nextMaintenance: '2024-04-25',
+    usageHours: 1680,
+    alerts: ['프로브 연결 오류', '긴급 수리 필요'],
+    notes: '프로브 케이블 손상으로 인한 오류'
+  },
+  {
+    id: 'EQ006',
+    name: '수액 주입기 #1',
+    type: 'infusion',
+    model: 'B.BraunPerfusor',
+    manufacturer: 'B.Braun',
+    status: 'operational',
+    location: '응급실 B-03',
+    lastMaintenance: '2024-02-05',
+    nextMaintenance: '2024-05-05',
+    batteryLevel: 78,
+    usageHours: 820,
+    alerts: [],
+    assignedTo: '이영희 (P002)'
+  },
+  {
+    id: 'EQ007',
+    name: '환자 모니터 #2',
+    type: 'monitor',
+    model: 'PhilipsX40',
+    manufacturer: 'Philips',
+    status: 'offline',
+    location: '창고',
+    lastMaintenance: '2024-01-20',
+    nextMaintenance: '2024-04-20',
+    batteryLevel: 0,
+    usageHours: 2890,
+    alerts: ['배터리 방전', '전원 공급 필요'],
+    notes: '예비 장비로 보관 중'
+  }
+];

--- a/src/mocks/index.ts
+++ b/src/mocks/index.ts
@@ -1,0 +1,11 @@
+export { mockBeds } from './bedData';
+export type { BedInfo } from './bedData';
+
+export { mockPatients } from './patientData';
+export type { Patient } from './patientData';
+
+export { mockStaff } from './staffData';
+export type { StaffMember } from './staffData';
+
+export { mockEquipment } from './equipmentData';
+export type { Equipment } from './equipmentData';

--- a/src/mocks/patientData.ts
+++ b/src/mocks/patientData.ts
@@ -1,0 +1,88 @@
+export interface Patient {
+  id: string;
+  name: string;
+  age: number;
+  gender: string;
+  diagnosis: string;
+  severity: 'critical' | 'urgent' | 'stable';
+  admissionTime: string;
+  bed: string;
+  vitals: {
+    heartRate: number;
+    bloodPressure: string;
+    temperature: number;
+    oxygenSaturation: number;
+  };
+  status: 'waiting' | 'treating' | 'stable' | 'discharged';
+}
+
+export const mockPatients: Patient[] = [
+  {
+    id: 'P001',
+    name: '김민수',
+    age: 45,
+    gender: '남성',
+    diagnosis: '급성 심근경색',
+    severity: 'critical',
+    admissionTime: '14:25',
+    bed: 'A-01',
+    vitals: {
+      heartRate: 95,
+      bloodPressure: '140/90',
+      temperature: 37.2,
+      oxygenSaturation: 98
+    },
+    status: 'treating'
+  },
+  {
+    id: 'P002',
+    name: '이영희',
+    age: 32,
+    gender: '여성',
+    diagnosis: '골절 의심',
+    severity: 'urgent',
+    admissionTime: '13:45',
+    bed: 'B-03',
+    vitals: {
+      heartRate: 82,
+      bloodPressure: '120/80',
+      temperature: 36.8,
+      oxygenSaturation: 99
+    },
+    status: 'waiting'
+  },
+  {
+    id: 'P003',
+    name: '박철수',
+    age: 67,
+    gender: '남성',
+    diagnosis: '호흡곤란',
+    severity: 'urgent',
+    admissionTime: '12:30',
+    bed: 'A-02',
+    vitals: {
+      heartRate: 105,
+      bloodPressure: '160/95',
+      temperature: 38.1,
+      oxygenSaturation: 92
+    },
+    status: 'treating'
+  },
+  {
+    id: 'P004',
+    name: '최미영',
+    age: 28,
+    gender: '여성',
+    diagnosis: '두통 및 어지러움',
+    severity: 'stable',
+    admissionTime: '11:15',
+    bed: 'C-01',
+    vitals: {
+      heartRate: 75,
+      bloodPressure: '115/75',
+      temperature: 36.5,
+      oxygenSaturation: 100
+    },
+    status: 'stable'
+  }
+];

--- a/src/mocks/staffData.ts
+++ b/src/mocks/staffData.ts
@@ -1,0 +1,119 @@
+export interface StaffMember {
+  id: string;
+  name: string;
+  role: 'doctor' | 'nurse' | 'technician' | 'admin';
+  department: string;
+  shift: 'day' | 'night' | 'evening';
+  status: 'on-duty' | 'off-duty' | 'break' | 'emergency';
+  phone: string;
+  email: string;
+  specialization?: string;
+  yearsOfExperience: number;
+  currentLocation: string;
+  shiftStart: string;
+  shiftEnd: string;
+  certifications: string[];
+  emergencyContact: string;
+}
+
+export const mockStaff: StaffMember[] = [
+  {
+    id: 'DOC001',
+    name: '김의사',
+    role: 'doctor',
+    department: '응급의학과',
+    shift: 'day',
+    status: 'on-duty',
+    phone: '010-0000-0001',
+    email: 'staff1@example.com',
+    specialization: '외상외과',
+    yearsOfExperience: 8,
+    currentLocation: '응급실 A구역',
+    shiftStart: '08:00',
+    shiftEnd: '18:00',
+    certifications: ['ACLS', 'ATLS', 'BLS'],
+    emergencyContact: '010-0000-1001'
+  },
+  {
+    id: 'DOC002',
+    name: '이의사',
+    role: 'doctor',
+    department: '응급의학과',
+    shift: 'night',
+    status: 'off-duty',
+    phone: '010-0000-0002',
+    email: 'staff2@example.com',
+    specialization: '내과',
+    yearsOfExperience: 12,
+    currentLocation: '대기실',
+    shiftStart: '18:00',
+    shiftEnd: '08:00',
+    certifications: ['ACLS', 'BLS', 'PALS'],
+    emergencyContact: '010-0000-1002'
+  },
+  {
+    id: 'NUR001',
+    name: '박간호사',
+    role: 'nurse',
+    department: '응급실',
+    shift: 'day',
+    status: 'on-duty',
+    phone: '010-0000-0003',
+    email: 'staff3@example.com',
+    yearsOfExperience: 5,
+    currentLocation: '응급실 B구역',
+    shiftStart: '08:00',
+    shiftEnd: '18:00',
+    certifications: ['BLS', 'ACLS'],
+    emergencyContact: '010-0000-1003'
+  },
+  {
+    id: 'NUR002',
+    name: '최간호사',
+    role: 'nurse',
+    department: '응급실',
+    shift: 'evening',
+    status: 'break',
+    phone: '010-0000-0004',
+    email: 'staff4@example.com',
+    yearsOfExperience: 3,
+    currentLocation: '휴게실',
+    shiftStart: '14:00',
+    shiftEnd: '22:00',
+    certifications: ['BLS'],
+    emergencyContact: '010-0000-1004'
+  },
+  {
+    id: 'TEC001',
+    name: '정기사',
+    role: 'technician',
+    department: '방사선과',
+    shift: 'day',
+    status: 'on-duty',
+    phone: '010-0000-0005',
+    email: 'staff5@example.com',
+    specialization: 'X-ray, CT',
+    yearsOfExperience: 7,
+    currentLocation: '영상의학과',
+    shiftStart: '08:00',
+    shiftEnd: '18:00',
+    certifications: ['방사선사', 'CT 전문'],
+    emergencyContact: '010-0000-1005'
+  },
+  {
+    id: 'ADM001',
+    name: '송관리자',
+    role: 'admin',
+    department: '응급실 관리',
+    shift: 'day',
+    status: 'on-duty',
+    phone: '010-0000-0006',
+    email: 'staff6@example.com',
+    yearsOfExperience: 10,
+    currentLocation: '관리실',
+    shiftStart: '08:00',
+    shiftEnd: '18:00',
+    certifications: ['병원관리사'],
+    emergencyContact: '010-0000-1006'
+  }
+];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,9 +23,7 @@
     /* Path mapping */
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./*"],
-      "@/components/*": ["./components/*"],
-      "@/styles/*": ["./styles/*"]
+      "@/*": ["./src/*"]
     }
   },
   "include": [


### PR DESCRIPTION
## Summary
- src/mocks/ 디렉토리 생성, 4개 파일의 인라인 목업 데이터 외부화
- 인터페이스 + 데이터 배열을 전용 파일로 분리 (~440줄 제거)
- barrel file(index.ts)로 re-export
- tsconfig paths 수정 (@/* → ./src/*)

Closes #12

## Test plan
- [ ] 빌드 정상 확인
- [ ] 모든 페이지에서 데이터 정상 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)