### PR TITLE
design(dashboard): improve visual design with medical colors

### DIFF
--- a/src/components/common/InfoCard.tsx
+++ b/src/components/common/InfoCard.tsx
@@ -8,24 +8,50 @@ interface InfoCardProps {
   subtitle?: string;
   variant?: 'default' | 'success' | 'warning' | 'destructive';
   icon?: React.ReactNode;
+  trend?: { value: string; positive?: boolean };
 }
 
-export function InfoCard({ title, value, subtitle, variant = 'default', icon }: InfoCardProps) {
+export function InfoCard({ title, value, subtitle, variant = 'default', icon, trend }: InfoCardProps) {
   const variantClasses = {
     default: 'border-border',
-    success: 'border-green-200 bg-green-50 dark:bg-green-950 dark:border-green-800',
-    warning: 'border-yellow-200 bg-yellow-50 dark:bg-yellow-950 dark:border-yellow-800',
-    destructive: 'border-red-200 bg-red-50 dark:bg-red-950 dark:border-red-800'
+    success: 'border-l-4 border-l-green-500 border-green-200 bg-green-50/50 dark:bg-green-950/30 dark:border-green-800',
+    warning: 'border-l-4 border-l-amber-500 border-amber-200 bg-amber-50/50 dark:bg-amber-950/30 dark:border-amber-800',
+    destructive: 'border-l-4 border-l-red-500 border-red-200 bg-red-50/50 dark:bg-red-950/30 dark:border-red-800'
+  };
+
+  const iconBgClasses = {
+    default: 'bg-primary/10 text-primary',
+    success: 'bg-green-100 text-green-600 dark:bg-green-900/50 dark:text-green-400',
+    warning: 'bg-amber-100 text-amber-600 dark:bg-amber-900/50 dark:text-amber-400',
+    destructive: 'bg-red-100 text-red-600 dark:bg-red-900/50 dark:text-red-400'
   };
 
   return (
-    <Card className={`${variantClasses[variant]} transition-all hover:shadow-md`}>
+    <Card className={`${variantClasses[variant]} shadow-sm transition-all hover:shadow-md`}>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <CardTitle className="text-sm font-medium text-muted-foreground">{title}</CardTitle>
-        {icon && <div className="text-muted-foreground">{icon}</div>}
+        {icon && (
+          <div className={`rounded-full p-2 ${iconBgClasses[variant]}`}>
+            {icon}
+          </div>
+        )}
       </CardHeader>
       <CardContent>
-        <div className="text-2xl font-bold">{value}</div>
+        <div className="flex items-baseline gap-2">
+          <div className="text-3xl font-bold tracking-tight">{value}</div>
+          {trend && (
+            <Badge
+              variant="secondary"
+              className={`text-xs ${
+                trend.positive
+                  ? 'bg-green-100 text-green-700 dark:bg-green-900/50 dark:text-green-400'
+                  : 'bg-red-100 text-red-700 dark:bg-red-900/50 dark:text-red-400'
+              }`}
+            >
+              {trend.positive ? '↑' : '↓'}{trend.value}
+            </Badge>
+          )}
+        </div>
         {subtitle && <p className="text-xs text-muted-foreground mt-1">{subtitle}</p>}
       </CardContent>
     </Card>

--- a/src/components/hospital/HospitalDashboard.tsx
+++ b/src/components/hospital/HospitalDashboard.tsx
@@ -7,11 +7,11 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from ".
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from "../ui/dialog";
 import { InfoCard } from "../common/InfoCard";
 import { generateMockRequests, MockRequest } from "../common/models";
-import { 
-  Building2, 
-  Users, 
-  Clock, 
-  CheckCircle2, 
+import {
+  Building2,
+  Users,
+  Clock,
+  CheckCircle2,
   AlertTriangle,
   Eye,
   Check,
@@ -19,7 +19,8 @@ import {
   Phone,
   Heart,
   Activity,
-  Brain
+  Brain,
+  TrendingUp
 } from 'lucide-react';
 import { toast } from "sonner";
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, PieChart, Pie, Cell } from 'recharts';
@@ -41,15 +42,15 @@ export function HospitalDashboard() {
   };
 
   const handleRequestAction = (requestId: string, action: 'accept' | 'hold') => {
-    setRequests(prev => prev.map(req => 
-      req.id === requestId 
+    setRequests(prev => prev.map(req =>
+      req.id === requestId
         ? { ...req, status: action === 'accept' ? 'matched' : 'pending' }
         : req
     ));
     toast(action === 'accept' ? "요청을 수락했습니다" : "요청을 보류했습니다");
   };
 
-  const filteredRequests = selectedSeverity === 'all' 
+  const filteredRequests = selectedSeverity === 'all'
     ? requests.filter(req => req.status === 'pending')
     : requests.filter(req => req.status === 'pending' && req.severity.toString() === selectedSeverity);
 
@@ -61,10 +62,10 @@ export function HospitalDashboard() {
     return { availableBeds, erQueue, avgWaitTime, todayProcessed };
   }, [requests]);
 
-  const getSeverityColor = (severity: number) => {
-    if (severity >= 4) return 'destructive';
-    if (severity >= 3) return 'warning';
-    return 'success';
+  const getSeverityBadgeClasses = (severity: number) => {
+    if (severity >= 4) return 'bg-red-100 text-red-700 border border-red-200 dark:bg-red-950/50 dark:text-red-400 dark:border-red-800';
+    if (severity >= 3) return 'bg-amber-100 text-amber-700 border border-amber-200 dark:bg-amber-950/50 dark:text-amber-400 dark:border-amber-800';
+    return 'bg-green-100 text-green-700 border border-green-200 dark:bg-green-950/50 dark:text-green-400 dark:border-green-800';
   };
 
   const getSeverityLabel = (severity: number) => {
@@ -78,6 +79,24 @@ export function HospitalDashboard() {
     return <Activity size={16} />;
   };
 
+  const getAlertBorderClass = (type: string) => {
+    switch (type) {
+      case 'warning': return 'border-l-4 border-l-amber-500';
+      case 'info': return 'border-l-4 border-l-blue-500';
+      case 'success': return 'border-l-4 border-l-green-500';
+      default: return 'border-l-4 border-l-gray-300';
+    }
+  };
+
+  const getAlertIconColor = (type: string) => {
+    switch (type) {
+      case 'warning': return 'text-amber-500';
+      case 'info': return 'text-blue-500';
+      case 'success': return 'text-green-500';
+      default: return 'text-gray-400';
+    }
+  };
+
   // 차트 데이터
   const [hourlyLoadData] = useState(() =>
     Array.from({ length: 24 }, (_, i) => ({
@@ -87,9 +106,9 @@ export function HospitalDashboard() {
   );
 
   const severityDistributionData = [
-    { name: '경미', value: requests.filter(r => r.severity <= 2).length, color: '#10b981' },
-    { name: '보통', value: requests.filter(r => r.severity === 3).length, color: '#f59e0b' },
-    { name: '심각', value: requests.filter(r => r.severity >= 4).length, color: '#ef4444' },
+    { name: '경미', value: requests.filter(r => r.severity <= 2).length, color: 'var(--chart-3)' },
+    { name: '보통', value: requests.filter(r => r.severity === 3).length, color: 'var(--chart-4)' },
+    { name: '심각', value: requests.filter(r => r.severity >= 4).length, color: 'var(--chart-5)' },
   ];
 
   return (
@@ -98,13 +117,21 @@ export function HospitalDashboard() {
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-4">
           <div className="flex items-center gap-2">
-            <Building2 className="text-primary" />
-            <span className="font-semibold">병원 응급실 대시보드</span>
+            <Building2 className="text-primary" size={22} />
+            <span className="text-lg font-semibold">병원 응급실 대시보드</span>
           </div>
-          <div className="flex items-center gap-2">
-            <span className={`text-sm ${accepting ? 'text-green-600' : 'text-red-600'}`}>
+          <div className="flex items-center gap-3">
+            <Badge
+              variant="outline"
+              className={`px-3 py-1 text-sm font-medium ${
+                accepting
+                  ? 'bg-green-100 text-green-700 border-green-300 dark:bg-green-950/50 dark:text-green-400 dark:border-green-700'
+                  : 'bg-red-100 text-red-700 border-red-300 dark:bg-red-950/50 dark:text-red-400 dark:border-red-700'
+              }`}
+            >
+              <span className={`inline-block w-2 h-2 rounded-full mr-1.5 ${accepting ? 'bg-green-500' : 'bg-red-500'}`} />
               {accepting ? '환자수용중' : '수용중단'}
-            </span>
+            </Badge>
             <Switch
               checked={accepting}
               onCheckedChange={handleAcceptingToggle}
@@ -116,52 +143,60 @@ export function HospitalDashboard() {
 
       {/* KPI 카드 */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-        <InfoCard 
-          title="가용 병상" 
-          value={kpiData.availableBeds} 
+        <InfoCard
+          title="가용 병상"
+          value={kpiData.availableBeds}
           subtitle="현재 이용 가능"
           variant="success"
-          icon={<Building2 size={16} />}
+          icon={<Building2 size={18} />}
+          trend={{ value: '2', positive: true }}
         />
-        <InfoCard 
-          title="ER 대기열" 
-          value={`${kpiData.erQueue}명`} 
+        <InfoCard
+          title="ER 대기열"
+          value={`${kpiData.erQueue}명`}
           subtitle="현재 대기 중"
           variant="warning"
-          icon={<Users size={16} />}
+          icon={<Users size={18} />}
+          trend={{ value: '3', positive: false }}
         />
-        <InfoCard 
-          title="평균 대기시간" 
-          value={`${kpiData.avgWaitTime}분`} 
+        <InfoCard
+          title="평균 대기시간"
+          value={`${kpiData.avgWaitTime}분`}
           subtitle="최근 1시간 평균"
           variant="default"
-          icon={<Clock size={16} />}
+          icon={<Clock size={18} />}
+          trend={{ value: '12%', positive: true }}
         />
-        <InfoCard 
-          title="오늘 처리" 
-          value={kpiData.todayProcessed} 
+        <InfoCard
+          title="오늘 처리"
+          value={kpiData.todayProcessed}
           subtitle="완료된 케이스"
           variant="default"
-          icon={<CheckCircle2 size={16} />}
+          icon={<CheckCircle2 size={18} />}
+          trend={{ value: '8%', positive: true }}
         />
       </div>
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         {/* 들어오는 요청 */}
         <div className="lg:col-span-2">
-          <Card>
+          <Card className="shadow-sm">
             <CardHeader>
               <div className="flex items-center justify-between">
-                <CardTitle className="flex items-center gap-2">
-                  <AlertTriangle size={16} />
+                <CardTitle className="flex items-center gap-2 text-base font-semibold">
+                  <AlertTriangle size={18} className="text-amber-500" />
                   들어오는 요청
+                  <Badge variant="secondary" className="ml-2 text-xs">
+                    {filteredRequests.length}건
+                  </Badge>
                 </CardTitle>
-                <div className="flex gap-2">
+                <div className="flex gap-1.5">
                   {[1, 2, 3, 4, 5].map(severity => (
                     <Button
                       key={severity}
                       size="sm"
                       variant={selectedSeverity === severity.toString() ? "default" : "outline"}
+                      className="text-xs h-7 px-2.5"
                       onClick={() => setSelectedSeverity(severity.toString())}
                     >
                       {getSeverityLabel(severity)}
@@ -170,6 +205,7 @@ export function HospitalDashboard() {
                   <Button
                     size="sm"
                     variant={selectedSeverity === 'all' ? "default" : "outline"}
+                    className="text-xs h-7 px-2.5"
                     onClick={() => setSelectedSeverity('all')}
                   >
                     전체
@@ -180,12 +216,12 @@ export function HospitalDashboard() {
             <CardContent>
               <Table>
                 <TableHeader>
-                  <TableRow>
-                    <TableHead>접수시각</TableHead>
-                    <TableHead>중증도</TableHead>
-                    <TableHead>거리/ETA</TableHead>
-                    <TableHead>증상</TableHead>
-                    <TableHead>액션</TableHead>
+                  <TableRow className="bg-muted/30">
+                    <TableHead className="font-semibold">접수시각</TableHead>
+                    <TableHead className="font-semibold">중증도</TableHead>
+                    <TableHead className="font-semibold">거리/ETA</TableHead>
+                    <TableHead className="font-semibold">증상</TableHead>
+                    <TableHead className="font-semibold">액션</TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
@@ -200,27 +236,35 @@ export function HospitalDashboard() {
                     </TableRow>
                   ) : (
                     filteredRequests.slice(0, 6).map((request) => (
-                      <TableRow key={request.id}>
-                        <TableCell>{request.time.toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' })}</TableCell>
+                      <TableRow key={request.id} className="hover:bg-muted/50 transition-colors">
+                        <TableCell className="font-mono text-sm">
+                          {request.time.toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' })}
+                        </TableCell>
                         <TableCell>
-                          <Badge variant={getSeverityColor(request.severity)}>
+                          <Badge
+                            variant="outline"
+                            className={getSeverityBadgeClasses(request.severity)}
+                          >
                             {getSeverityLabel(request.severity)} ({request.severity})
                           </Badge>
                         </TableCell>
                         <TableCell>
-                          {request.distanceKm}km / {request.eta}분
+                          <span className="text-sm">
+                            {request.distanceKm}km / <span className="font-medium">{request.eta}분</span>
+                          </span>
                         </TableCell>
                         <TableCell>
                           <div className="flex items-center gap-2">
-                            {getSymptomIcon(request.symptom)}
-                            {request.symptom}
+                            <span className="text-muted-foreground">{getSymptomIcon(request.symptom)}</span>
+                            <span className="text-sm">{request.symptom}</span>
                           </div>
                         </TableCell>
                         <TableCell>
-                          <div className="flex gap-2">
+                          <div className="flex gap-1.5">
                             <RequestDetailDialog request={request} />
                             <Button
                               size="sm"
+                              className="h-7 px-2"
                               onClick={() => handleRequestAction(request.id, 'accept')}
                               aria-label="수락"
                             >
@@ -229,6 +273,7 @@ export function HospitalDashboard() {
                             <Button
                               size="sm"
                               variant="outline"
+                              className="h-7 px-2"
                               onClick={() => handleRequestAction(request.id, 'hold')}
                               aria-label="보류"
                             >
@@ -246,28 +291,31 @@ export function HospitalDashboard() {
         </div>
 
         {/* 사이드 패널 */}
-        <div className="space-y-4">
+        <div className="space-y-6">
           {/* 실시간 알림 */}
-          <Card>
+          <Card className="shadow-sm">
             <CardHeader>
-              <CardTitle>실시간 알림</CardTitle>
+              <CardTitle className="text-base font-semibold">실시간 알림</CardTitle>
             </CardHeader>
-            <CardContent className="space-y-2" aria-live="polite">
+            <CardContent className="space-y-3" aria-live="polite">
               {recentAlerts.map((alert, index) => (
-                <div key={index} className="p-2 rounded bg-muted/50">
-                  <p className="text-sm">{alert.message}</p>
-                  <p className="text-xs text-muted-foreground">{alert.time}</p>
+                <div
+                  key={index}
+                  className={`p-3 rounded-lg bg-muted/40 ${getAlertBorderClass(alert.type)} transition-all hover:bg-muted/60`}
+                >
+                  <p className={`text-sm font-medium ${getAlertIconColor(alert.type)}`}>{alert.message}</p>
+                  <p className="text-xs text-muted-foreground mt-1">{alert.time}</p>
                 </div>
               ))}
             </CardContent>
           </Card>
 
           {/* 중증도 분포 차트 */}
-          <Card>
+          <Card className="shadow-sm">
             <CardHeader>
-              <CardTitle>중증도 분포</CardTitle>
+              <CardTitle className="text-base font-semibold">중증도 분포</CardTitle>
             </CardHeader>
-            <CardContent>
+            <CardContent className="pb-4">
               <ResponsiveContainer width="100%" height={200}>
                 <PieChart>
                   <Pie
@@ -276,15 +324,26 @@ export function HospitalDashboard() {
                     cy="50%"
                     labelLine={false}
                     label={({ name, percent }) => `${name} ${(percent * 100).toFixed(0)}%`}
-                    outerRadius={60}
+                    outerRadius={65}
+                    innerRadius={30}
                     fill="#8884d8"
                     dataKey="value"
+                    strokeWidth={2}
+                    stroke="var(--background)"
                   >
                     {severityDistributionData.map((entry, index) => (
                       <Cell key={`cell-${index}`} fill={entry.color} />
                     ))}
                   </Pie>
-                  <Tooltip />
+                  <Tooltip
+                    contentStyle={{
+                      borderRadius: '8px',
+                      border: '1px solid var(--border)',
+                      backgroundColor: 'var(--card)',
+                      color: 'var(--card-foreground)',
+                      fontSize: '12px',
+                    }}
+                  />
                 </PieChart>
               </ResponsiveContainer>
             </CardContent>
@@ -293,18 +352,45 @@ export function HospitalDashboard() {
       </div>
 
       {/* 시간대별 부하 차트 */}
-      <Card>
+      <Card className="shadow-sm">
         <CardHeader>
-          <CardTitle>시간대별 환자 부하</CardTitle>
+          <CardTitle className="flex items-center gap-2 text-base font-semibold">
+            <TrendingUp size={18} className="text-primary" />
+            시간대별 환자 부하
+          </CardTitle>
         </CardHeader>
-        <CardContent>
+        <CardContent className="pb-4">
           <ResponsiveContainer width="100%" height={300}>
             <LineChart data={hourlyLoadData}>
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="hour" />
-              <YAxis />
-              <Tooltip />
-              <Line type="monotone" dataKey="patients" stroke="#8884d8" strokeWidth={2} />
+              <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" opacity={0.5} />
+              <XAxis
+                dataKey="hour"
+                tick={{ fontSize: 12, fill: 'var(--muted-foreground)' }}
+                tickLine={{ stroke: 'var(--border)' }}
+                axisLine={{ stroke: 'var(--border)' }}
+              />
+              <YAxis
+                tick={{ fontSize: 12, fill: 'var(--muted-foreground)' }}
+                tickLine={{ stroke: 'var(--border)' }}
+                axisLine={{ stroke: 'var(--border)' }}
+              />
+              <Tooltip
+                contentStyle={{
+                  borderRadius: '8px',
+                  border: '1px solid var(--border)',
+                  backgroundColor: 'var(--card)',
+                  color: 'var(--card-foreground)',
+                  fontSize: '12px',
+                }}
+              />
+              <Line
+                type="monotone"
+                dataKey="patients"
+                stroke="var(--chart-1)"
+                strokeWidth={2.5}
+                dot={{ r: 3, fill: 'var(--chart-1)', strokeWidth: 0 }}
+                activeDot={{ r: 5, fill: 'var(--chart-1)', strokeWidth: 2, stroke: 'var(--background)' }}
+              />
             </LineChart>
           </ResponsiveContainer>
         </CardContent>
@@ -317,7 +403,7 @@ function RequestDetailDialog({ request }: { request: MockRequest }) {
   return (
     <Dialog>
       <DialogTrigger asChild>
-        <Button size="sm" variant="outline" aria-label="상세보기">
+        <Button size="sm" variant="outline" className="h-7 px-2" aria-label="상세보기">
           <Eye size={14} />
         </Button>
       </DialogTrigger>


### PR DESCRIPTION
## Summary
- KPI 카드에 컬러 바, 아이콘 배경, 변화량 Badge 추가
- 중증도 Badge에 의미 있는 색상 (빨강/주황/초록)
- 차트 CSS 변수 기반 색상, 도넛 차트로 변경
- 알림 타입별 좌측 컬러 바
- 수용 상태 Badge 스타일 개선

🤖 Generated with [Claude Code](https://claude.com/claude-code)