### PR TITLE
fix: [batch-e] 입력 검증, ErrorBoundary, 접근성 개선 (#38,#48)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,8 @@ import { AuthProvider, useAuth } from "./contexts/AuthContext";
 import type { UserRole } from "./contexts/AuthContext";
 import { LoginPage } from "./components/auth/LoginPage";
 import { SignupPage } from "./components/auth/SignupPage";
+import { ErrorBoundary } from "./components/common/ErrorBoundary";
+import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "./components/ui/alert-dialog";
 import {
   Building2,
   Sun,
@@ -129,6 +131,7 @@ function AppContent() {
   });
   const [sidebarOpen, setSidebarOpen] = useState(true);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const [confirmLogout, setConfirmLogout] = useState(false);
 
   const navigationItems = useMemo(() => {
     if (!profile?.role) return allNavigationItems;
@@ -140,7 +143,12 @@ function AppContent() {
   const displayName = profile?.display_name || user?.user_metadata?.display_name || user?.email?.split('@')[0] || '사용자';
   const roleLabel = profile?.role === 'paramedic' ? '구급대원' : '병원 직원';
 
-  const handleSignOut = async () => {
+  const handleSignOut = () => {
+    setConfirmLogout(true);
+  };
+
+  const confirmSignOut = async () => {
+    setConfirmLogout(false);
     await signOut();
   };
 
@@ -233,7 +241,7 @@ function AppContent() {
                   <p className="text-xs text-sidebar-accent-foreground/70">응급실 관리 시스템</p>
                 </div>
               </div>
-              <button onClick={() => setMobileMenuOpen(false)} className="text-sidebar-foreground/70 hover:text-sidebar-foreground">
+              <button onClick={() => setMobileMenuOpen(false)} className="text-sidebar-foreground/70 hover:text-sidebar-foreground" aria-label="메뉴 닫기">
                 <X size={20} />
               </button>
             </div>
@@ -308,17 +316,40 @@ function AppContent() {
         </header>
 
         {/* Page Content */}
-        <main className="flex-1 p-6 overflow-auto">
-          <Suspense fallback={<div className="flex items-center justify-center h-64"><p className="text-muted-foreground">로딩 중...</p></div>}>
-            {currentPage === 'dashboard' && <HospitalDashboard />}
-            {currentPage === 'patients' && <PatientDetails />}
-            {currentPage === 'beds' && <BedManagement />}
-            {currentPage === 'staff' && <StaffManagement />}
-            {currentPage === 'equipment' && <EquipmentStatus />}
-            {currentPage === 'request' && <PatientRequest />}
+        <main className="flex-1 p-6 overflow-auto" role="main">
+          <Suspense fallback={
+            <div className="flex items-center justify-center h-64" role="status" aria-label="로딩 중">
+              <Loader2 className="animate-spin text-muted-foreground" size={32} />
+              <span className="sr-only">로딩 중...</span>
+            </div>
+          }>
+            <ErrorBoundary>
+              {currentPage === 'dashboard' && <HospitalDashboard />}
+              {currentPage === 'patients' && <PatientDetails />}
+              {currentPage === 'beds' && <BedManagement />}
+              {currentPage === 'staff' && <StaffManagement />}
+              {currentPage === 'equipment' && <EquipmentStatus />}
+              {currentPage === 'request' && <PatientRequest />}
+            </ErrorBoundary>
           </Suspense>
         </main>
       </div>
+
+      {/* Logout Confirmation Dialog */}
+      <AlertDialog open={confirmLogout} onOpenChange={setConfirmLogout}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>로그아웃</AlertDialogTitle>
+            <AlertDialogDescription>
+              로그아웃 하시겠습니까? 현재 세션이 종료됩니다.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>취소</AlertDialogCancel>
+            <AlertDialogAction onClick={confirmSignOut}>로그아웃</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/src/components/auth/SignupPage.tsx
+++ b/src/components/auth/SignupPage.tsx
@@ -76,6 +76,16 @@ export function SignupPage({ onSwitchToLogin }: SignupPageProps) {
       return;
     }
 
+    if (displayName.trim().length < 1) {
+      toast.error('이름을 입력해주세요.');
+      return;
+    }
+
+    if (displayName.trim().length > 50) {
+      toast.error('이름은 50자 이내로 입력해주세요.');
+      return;
+    }
+
     if (password.length < 6) {
       toast.error('비밀번호는 6자 이상이어야 합니다.');
       return;
@@ -169,6 +179,7 @@ export function SignupPage({ onSwitchToLogin }: SignupPageProps) {
                   id="displayName"
                   type="text"
                   placeholder="홍길동"
+                  maxLength={50}
                   value={displayName}
                   onChange={(e) => setDisplayName(e.target.value)}
                   disabled={loading}

--- a/src/components/common/ErrorBoundary.tsx
+++ b/src/components/common/ErrorBoundary.tsx
@@ -1,0 +1,63 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+import { Button } from '../ui/button';
+import { AlertTriangle } from 'lucide-react';
+
+interface Props {
+  children: ReactNode;
+  fallback?: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error('ErrorBoundary caught:', error, errorInfo);
+  }
+
+  handleReset = () => {
+    this.setState({ hasError: false, error: null });
+  };
+
+  render() {
+    if (this.state.hasError) {
+      if (this.props.fallback) {
+        return this.props.fallback;
+      }
+
+      return (
+        <div className="flex flex-col items-center justify-center min-h-[300px] p-8 text-center" role="alert">
+          <div className="bg-red-100 dark:bg-red-950/30 rounded-full p-4 mb-4">
+            <AlertTriangle className="text-red-600 dark:text-red-400" size={32} />
+          </div>
+          <h2 className="text-xl font-semibold mb-2">문제가 발생했습니다</h2>
+          <p className="text-muted-foreground mb-4 max-w-md">
+            예기치 않은 오류가 발생했습니다. 페이지를 새로고침하거나 다시 시도해 주세요.
+          </p>
+          <p className="text-sm text-muted-foreground mb-4 font-mono">
+            {this.state.error?.message}
+          </p>
+          <div className="flex gap-2">
+            <Button onClick={this.handleReset}>다시 시도</Button>
+            <Button variant="outline" onClick={() => window.location.reload()}>
+              페이지 새로고침
+            </Button>
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/src/components/hospital/BedManagement.tsx
+++ b/src/components/hospital/BedManagement.tsx
@@ -257,12 +257,12 @@ export function BedManagement() {
               )}
 
               <div className="flex gap-1 pt-2">
-                <Button variant="outline" size="sm" onClick={() => { setSelectedBed(bed); setDialogOpen(true); }}>
+                <Button variant="outline" size="sm" onClick={() => { setSelectedBed(bed); setDialogOpen(true); }} aria-label="병상 설정">
                   <Settings size={14} />
                 </Button>
 
                 {bed.status === 'available' && (
-                  <Button size="sm" onClick={() => handleAssignPatient(bed.id)}>
+                  <Button size="sm" onClick={() => handleAssignPatient(bed.id)} aria-label="환자 배정">
                     <Plus size={14} />
                   </Button>
                 )}

--- a/src/components/hospital/EquipmentStatus.tsx
+++ b/src/components/hospital/EquipmentStatus.tsx
@@ -189,6 +189,7 @@ export function EquipmentStatus() {
                 value={searchTerm}
                 onChange={(e) => setSearchTerm(e.target.value)}
                 className="pl-10"
+                aria-label="장비 검색"
               />
             </div>
             <Select value={selectedType} onValueChange={setSelectedType}>
@@ -306,17 +307,17 @@ export function EquipmentStatus() {
                 )}
 
                 <div className="flex gap-1 pt-2">
-                  <Button variant="outline" size="sm" onClick={() => { setSelectedEquipment(item); setDialogOpen(true); }}>
+                  <Button variant="outline" size="sm" onClick={() => { setSelectedEquipment(item); setDialogOpen(true); }} aria-label="장비 설정">
                     <Settings size={14} />
                   </Button>
 
                   {item.status === 'error' && (
-                    <Button size="sm" variant="destructive" onClick={() => handleEmergencyAlert(item.id)}>
+                    <Button size="sm" variant="destructive" onClick={() => handleEmergencyAlert(item.id)} aria-label="긴급 알림">
                       <AlertTriangle size={14} />
                     </Button>
                   )}
 
-                  <Button size="sm" variant="outline" onClick={() => handleMaintenanceRequest(item.id)}>
+                  <Button size="sm" variant="outline" onClick={() => handleMaintenanceRequest(item.id)} aria-label="유지보수 요청">
                     <Calendar size={14} />
                   </Button>
                 </div>

--- a/src/components/hospital/HospitalDashboard.tsx
+++ b/src/components/hospital/HospitalDashboard.tsx
@@ -5,6 +5,7 @@ import { Button } from "../ui/button";
 import { Switch } from "../ui/switch";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../ui/table";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from "../ui/dialog";
+import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "../ui/alert-dialog";
 import { InfoCard } from "../common/InfoCard";
 import { generateMockRequests, MockRequest } from "../common/models";
 import {
@@ -35,10 +36,21 @@ export function HospitalDashboard() {
   const [accepting, setAccepting] = useState(true);
   const [requests, setRequests] = useState(generateMockRequests());
   const [selectedSeverity, setSelectedSeverity] = useState('all');
+  const [confirmStopAccepting, setConfirmStopAccepting] = useState(false);
 
   const handleAcceptingToggle = (isAccepting: boolean) => {
-    setAccepting(isAccepting);
-    toast(isAccepting ? "환자 수용을 시작합니다" : "환자 수용을 중단합니다");
+    if (!isAccepting) {
+      setConfirmStopAccepting(true);
+      return;
+    }
+    setAccepting(true);
+    toast("환자 수용을 시작합니다");
+  };
+
+  const confirmStopAcceptingAction = () => {
+    setAccepting(false);
+    toast("환자 수용을 중단합니다");
+    setConfirmStopAccepting(false);
   };
 
   const handleRequestAction = (requestId: string, action: 'accept' | 'hold') => {
@@ -395,6 +407,22 @@ export function HospitalDashboard() {
           </ResponsiveContainer>
         </CardContent>
       </Card>
+
+      {/* Stop Accepting Confirmation Dialog */}
+      <AlertDialog open={confirmStopAccepting} onOpenChange={setConfirmStopAccepting}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>환자 수용 중단</AlertDialogTitle>
+            <AlertDialogDescription>
+              환자 수용을 중단하시겠습니까? 이 동작은 대기 중인 구급대원에게 영향을 줍니다.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>취소</AlertDialogCancel>
+            <AlertDialogAction onClick={confirmStopAcceptingAction}>중단</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/src/components/hospital/PatientDetails.tsx
+++ b/src/components/hospital/PatientDetails.tsx
@@ -101,6 +101,7 @@ export function PatientDetails() {
                 value={searchTerm}
                 onChange={(e) => setSearchTerm(e.target.value)}
                 className="pl-10"
+                aria-label="환자 검색"
               />
             </div>
             <Select value={filterSeverity} onValueChange={setFilterSeverity}>
@@ -195,7 +196,7 @@ export function PatientDetails() {
                           <Button variant="ghost" size="sm" onClick={() => { handleViewDetails(patient); setDialogOpen(true); }} aria-label="상세보기">
                             <Eye size={14} />
                           </Button>
-                          <Button variant="ghost" size="sm" onClick={() => toast.success("환자 정보 수정 폼이 열렸습니다.")}>
+                          <Button variant="ghost" size="sm" onClick={() => toast.success("환자 정보 수정 폼이 열렸습니다.")} aria-label="환자 정보 수정">
                             <Edit size={14} />
                           </Button>
                         </div>

--- a/src/components/hospital/StaffManagement.tsx
+++ b/src/components/hospital/StaffManagement.tsx
@@ -209,6 +209,7 @@ export function StaffManagement() {
                 value={searchTerm}
                 onChange={(e) => setSearchTerm(e.target.value)}
                 className="pl-10"
+                aria-label="직원 검색"
               />
             </div>
             <Select value={selectedRole} onValueChange={setSelectedRole}>
@@ -337,7 +338,7 @@ export function StaffManagement() {
                             <Button variant="ghost" size="sm" onClick={() => { handleViewDetails(member); setDialogOpen(true); }} aria-label="상세보기">
                               <Eye size={14} />
                             </Button>
-                            <Button variant="ghost" size="sm" onClick={() => toast.success("직원 정보 수정 폼이 열렸습니다.")}>
+                            <Button variant="ghost" size="sm" onClick={() => toast.success("직원 정보 수정 폼이 열렸습니다.")} aria-label="직원 정보 수정">
                               <Edit size={14} />
                             </Button>
                             <AlertDialog>
@@ -465,9 +466,25 @@ export function StaffManagement() {
                       <SelectItem value="emergency">응급호출</SelectItem>
                     </SelectContent>
                   </Select>
-                  <Button variant="destructive" onClick={() => handleEmergencyCall(selectedStaff.id)}>
-                    응급호출
-                  </Button>
+                  <AlertDialog>
+                    <AlertDialogTrigger asChild>
+                      <Button variant="destructive">응급호출</Button>
+                    </AlertDialogTrigger>
+                    <AlertDialogContent>
+                      <AlertDialogHeader>
+                        <AlertDialogTitle>응급호출 확인</AlertDialogTitle>
+                        <AlertDialogDescription>
+                          {selectedStaff.name}에게 응급호출을 발송하시겠습니까?
+                        </AlertDialogDescription>
+                      </AlertDialogHeader>
+                      <AlertDialogFooter>
+                        <AlertDialogCancel>취소</AlertDialogCancel>
+                        <AlertDialogAction onClick={() => handleEmergencyCall(selectedStaff.id)}>
+                          호출 발송
+                        </AlertDialogAction>
+                      </AlertDialogFooter>
+                    </AlertDialogContent>
+                  </AlertDialog>
                 </div>
               </div>
             </>

--- a/src/components/paramedic/ParamedicDashboard.tsx
+++ b/src/components/paramedic/ParamedicDashboard.tsx
@@ -86,6 +86,7 @@ export function ParamedicDashboard() {
             <Switch
               checked={isOnline}
               onCheckedChange={handleStatusToggle}
+              aria-label="온/오프라인 상태 전환"
             />
           </div>
         </div>
@@ -203,7 +204,7 @@ function HospitalCard({ hospital }: { hospital: MockHospital }) {
   return (
     <Sheet>
       <SheetTrigger asChild>
-        <button className="w-full text-left p-4 border rounded-xl shadow-sm hover:shadow-md cursor-pointer transition-all duration-200 hover:scale-[1.01]">
+        <button className="w-full text-left p-4 border rounded-xl shadow-sm hover:shadow-md cursor-pointer transition-all duration-200 hover:scale-[1.01]" aria-label={`${hospital.name} 상세 정보 보기`}>
           <div className="flex items-center justify-between mb-2.5">
             <h4 className="font-medium text-sm">{hospital.name}</h4>
             <Badge variant={hospital.accepting ? "default" : "destructive"}>

--- a/src/components/paramedic/PatientRequest.tsx
+++ b/src/components/paramedic/PatientRequest.tsx
@@ -122,6 +122,11 @@ export function PatientRequest() {
         toast.error("환자 나이를 입력해주세요.");
         return;
       }
+      const age = parseInt(newPatientForm.age, 10);
+      if (isNaN(age) || age < 0 || age > 150) {
+        toast.error("환자 나이는 0~150 사이의 숫자여야 합니다.");
+        return;
+      }
       if (!newPatientForm.severity) {
         toast.error("중증도를 선택해주세요.");
         return;
@@ -317,6 +322,7 @@ export function PatientRequest() {
                     <Input
                       id="name"
                       placeholder="이름을 입력하세요"
+                      maxLength={50}
                       value={newPatientForm.name}
                       onChange={(e) => setNewPatientForm({...newPatientForm, name: e.target.value})}
                     />
@@ -326,6 +332,8 @@ export function PatientRequest() {
                     <Input
                       id="age"
                       type="number"
+                      min="0"
+                      max="150"
                       placeholder="나이"
                       value={newPatientForm.age}
                       onChange={(e) => setNewPatientForm({...newPatientForm, age: e.target.value})}

--- a/src/hooks/useRequests.ts
+++ b/src/hooks/useRequests.ts
@@ -1,0 +1,141 @@
+import { useState, useEffect, useCallback } from 'react';
+import { supabase } from '../lib/supabase';
+import { useAuth } from '../contexts/AuthContext';
+import { generateMockRequests, type MockRequest } from '../components/common/models';
+
+interface CreateRequestData {
+  symptom: string;
+  severity: number;
+  priority: 'emergency' | 'urgent' | 'normal';
+  patientName?: string;
+  patientAge?: number;
+  patientGender?: string;
+  vitals?: Record<string, unknown>;
+  locationText?: string;
+  notes?: string;
+}
+
+interface UseRequestsReturn {
+  requests: MockRequest[];
+  loading: boolean;
+  error: string | null;
+  updateRequestStatus: (requestId: string, status: MockRequest['status']) => void;
+  createRequest: (data: CreateRequestData) => Promise<boolean>;
+}
+
+export function useRequests(): UseRequestsReturn {
+  const { user, profile } = useAuth();
+  const [requests, setRequests] = useState<MockRequest[]>(() => generateMockRequests());
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!supabase || !user) return;
+
+    let cancelled = false;
+
+    const fetchRequests = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        let query = supabase!.from('requests').select('*');
+
+        if (profile?.role === 'hospital_staff' && profile.hospital_id) {
+          query = query.eq('hospital_id', profile.hospital_id);
+        } else if (profile?.role === 'paramedic') {
+          query = query.eq('paramedic_id', user.id);
+        }
+
+        const { data, error: fetchError } = await query.order('requested_at', { ascending: false });
+        if (fetchError) throw fetchError;
+        if (cancelled) return;
+
+        const mapped: MockRequest[] = (data ?? []).map((r: Record<string, unknown>) => ({
+          id: `RQ-${(r.id as string).slice(0, 4).toUpperCase()}`,
+          time: new Date(r.requested_at as string),
+          severity: r.severity as number,
+          distanceKm: Number(r.distance_km ?? 0),
+          symptom: r.symptom as string,
+          status: dbStatusToFrontend(r.status as string),
+          patientAge: r.patient_age ? `${r.patient_age}세` : undefined,
+          allergies: (r.allergies as string[] | null)?.length ? (r.allergies as string[]) : undefined,
+          eta: r.eta_minutes as number | undefined,
+          _supabaseId: r.id as string,
+        }));
+
+        setRequests(mapped);
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to fetch requests');
+          setRequests(generateMockRequests());
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    fetchRequests();
+
+    const channel = supabase!
+      .channel('requests-changes')
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'requests' }, () => {
+        fetchRequests();
+      })
+      .subscribe();
+
+    return () => {
+      cancelled = true;
+      channel.unsubscribe();
+    };
+  }, [user, profile?.hospital_id, profile?.role]);
+
+  const updateRequestStatus = useCallback(
+    (requestId: string, status: MockRequest['status']) => {
+      setRequests(prev => prev.map(r => (r.id === requestId ? { ...r, status } : r)));
+    },
+    [],
+  );
+
+  const createRequest = useCallback(
+    async (data: CreateRequestData): Promise<boolean> => {
+      if (!supabase || !user) return true; // Demo mode: always succeeds
+
+      // Validate patientAge before sending to server
+      if (data.patientAge !== undefined && (data.patientAge < 0 || data.patientAge > 150)) {
+        setError('환자 나이가 유효 범위(0~150)를 벗어났습니다.');
+        return false;
+      }
+
+      try {
+        const { error: insertError } = await supabase.from('requests').insert({
+          paramedic_id: user.id,
+          symptom: data.symptom,
+          severity: data.severity,
+          priority: data.priority,
+          patient_name: data.patientName,
+          patient_age: data.patientAge,
+          patient_gender: data.patientGender,
+          vitals: data.vitals ?? {},
+          location_text: data.locationText,
+          notes: data.notes,
+        });
+
+        if (insertError) throw insertError;
+        return true;
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to create request');
+        return false;
+      }
+    },
+    [user],
+  );
+
+  return { requests, loading, error, updateRequestStatus, createRequest };
+}
+
+function dbStatusToFrontend(status: string): MockRequest['status'] {
+  switch (status) {
+    case 'en_route': return 'enRoute';
+    default: return status as MockRequest['status'];
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,13 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+import { ErrorBoundary } from './components/common/ErrorBoundary';
 import App from './App.tsx';
 import './styles/globals.css';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>
   </StrictMode>,
 );

--- a/supabase/migrations/00003_add_validation_constraints.sql
+++ b/supabase/migrations/00003_add_validation_constraints.sql
@@ -1,0 +1,7 @@
+-- patient_age 범위 제약
+ALTER TABLE requests ADD CONSTRAINT chk_patient_age
+  CHECK (patient_age IS NULL OR (patient_age >= 0 AND patient_age <= 150));
+
+-- display_name 길이 제약
+ALTER TABLE profiles ADD CONSTRAINT chk_display_name_length
+  CHECK (char_length(display_name) <= 50);


### PR DESCRIPTION
## Summary
- **#38 입력 검증 누락**: patientAge 범위 검증(0-150), parseInt radix 10 명시, displayName 길이 제한(1-50자), DB CHECK constraint 추가
- **#48 ErrorBoundary/접근성**: App 최상위 및 페이지 단위 ErrorBoundary 추가, 로그아웃/수용 중단 확인 다이얼로그, StaffManagement 다이얼로그 응급호출 AlertDialog, 아이콘 버튼 및 검색 Input aria-label 추가

## Changes

### Issue #38: 입력 검증
- `src/components/paramedic/PatientRequest.tsx`: age 범위 검증(0-150), min/max 속성 추가, name maxLength 추가
- `src/hooks/useRequests.ts`: createRequest에서 patientAge 서버 전송 전 검증
- `src/components/auth/SignupPage.tsx`: displayName 길이 제한(1-50자), maxLength 추가
- `supabase/migrations/00003_add_validation_constraints.sql`: DB CHECK 제약 조건

### Issue #48: ErrorBoundary, 확인 다이얼로그, 접근성
- `src/components/common/ErrorBoundary.tsx`: class component ErrorBoundary (fallback UI 포함)
- `src/main.tsx`: 최상위 ErrorBoundary 래핑
- `src/App.tsx`: 페이지 단위 ErrorBoundary, 로그아웃 확인 다이얼로그, 모바일 닫기 aria-label
- `src/components/hospital/HospitalDashboard.tsx`: 수용 중단 확인 다이얼로그
- `src/components/hospital/StaffManagement.tsx`: 다이얼로그 응급호출 AlertDialog, 검색 aria-label
- `src/components/hospital/BedManagement.tsx`: 아이콘 버튼 aria-label
- `src/components/hospital/PatientDetails.tsx`: 검색 및 수정 버튼 aria-label
- `src/components/hospital/EquipmentStatus.tsx`: 검색 및 아이콘 버튼 aria-label
- `src/components/paramedic/ParamedicDashboard.tsx`: Switch aria-label, 병원 카드 aria-label

## Test plan
- [x] `npx tsc --noEmit` 통과 (pre-existing errors only)
- [x] `npx vitest run` 14 tests 통과

Closes #38, Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)