### PR TITLE
fix: [batch-b] DB 동기화, OAuth, AuthContext 수정 (#40,#42,#43)

### DIFF
--- a/src/components/auth/SignupPage.tsx
+++ b/src/components/auth/SignupPage.tsx
@@ -125,6 +125,12 @@ export function SignupPage({ onSwitchToLogin }: SignupPageProps) {
   const handleGoogleSignup = async () => {
     setLoading(true);
     try {
+      // Save selected role info to localStorage before OAuth redirect
+      localStorage.setItem('pending_signup_role', role);
+      if (role === 'hospital_staff' && hospitalId) {
+        localStorage.setItem('pending_signup_hospital_id', hospitalId);
+      }
+
       const { error } = await supabase.auth.signInWithOAuth({
         provider: 'google',
         options: {
@@ -132,10 +138,14 @@ export function SignupPage({ onSwitchToLogin }: SignupPageProps) {
         },
       });
       if (error) {
+        localStorage.removeItem('pending_signup_role');
+        localStorage.removeItem('pending_signup_hospital_id');
         toast.error(`Google 회원가입 실패: ${error.message}`);
         setLoading(false);
       }
     } catch {
+      localStorage.removeItem('pending_signup_role');
+      localStorage.removeItem('pending_signup_hospital_id');
       toast.error('Google 회원가입 중 오류가 발생했습니다.');
       setLoading(false);
     }

--- a/src/components/hospital/PatientDetails.tsx
+++ b/src/components/hospital/PatientDetails.tsx
@@ -12,6 +12,7 @@ import { Separator } from "../ui/separator";
 import { toast } from "sonner";
 import { getSeverityText, getPatientStatusText } from "../../utils/statusHelpers";
 import { mockPatients, type Patient } from "@/mocks/patientData";
+import { supabase } from "../../lib/supabase";
 import {
   Search,
   UserPlus,
@@ -314,12 +315,45 @@ export function PatientDetails() {
                   />
                 </div>
 
+                {/* 상태 변경 */}
+                <div>
+                  <Label className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">상태 변경</Label>
+                  <Select
+                    defaultValue={selectedPatient.status}
+                    onValueChange={(value) => handleUpdateStatus(selectedPatient.id, value)}
+                  >
+                    <SelectTrigger className="mt-2">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="waiting">대기중</SelectItem>
+                      <SelectItem value="treating">치료중</SelectItem>
+                      <SelectItem value="stable">안정</SelectItem>
+                      <SelectItem value="discharged">퇴원</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+
                 <div className="flex justify-end gap-2">
-                  <Button variant="outline" onClick={() => toast.success("환자 정보가 저장되었습니다.")}>
+                  <Button variant="outline" onClick={async () => {
+                    const notesEl = document.getElementById('notes') as HTMLTextAreaElement;
+                    const notesValue = notesEl?.value ?? '';
+                    if (supabase) {
+                      const supabaseId = (selectedPatient as unknown as Record<string, unknown>)?._supabaseId as string | undefined;
+                      if (supabaseId) {
+                        const { error } = await supabase
+                          .from('patients')
+                          .update({ notes: notesValue })
+                          .eq('id', supabaseId);
+                        if (error) {
+                          toast.error('저장에 실패했습니다.');
+                          return;
+                        }
+                      }
+                    }
+                    toast.success("환자 정보가 저장되었습니다.");
+                  }}>
                     저장
-                  </Button>
-                  <Button onClick={() => handleUpdateStatus(selectedPatient.id, "updated")}>
-                    상태 업데이트
                   </Button>
                 </div>
               </div>

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -33,6 +33,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [loading, setLoading] = useState(true);
 
   const fetchProfile = useCallback(async (userId: string) => {
+    if (!supabase) return;
     try {
       const { data, error } = await supabase
         .from('profiles')
@@ -59,23 +60,43 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   useEffect(() => {
-    // Get initial session
-    supabase.auth.getSession().then(({ data: { session: currentSession } }) => {
-      setSession(currentSession);
-      setUser(currentSession?.user ?? null);
+    if (!supabase) {
+      setProfile({ role: 'hospital_staff', hospital_id: null, display_name: 'Demo User' });
+      setLoading(false);
+      return;
+    }
 
-      if (currentSession?.user) {
-        fetchProfile(currentSession.user.id).finally(() => setLoading(false));
-      } else {
-        setLoading(false);
-      }
-    });
+    let isMounted = true;
 
-    // Listen for auth changes
+    // 1. Register listener first to prevent event loss
     const { data: { subscription } } = supabase.auth.onAuthStateChange(
-      async (_event, newSession) => {
+      async (event, newSession) => {
+        if (!isMounted) return;
+
         setSession(newSession);
         setUser(newSession?.user ?? null);
+
+        if (event === 'SIGNED_OUT') {
+          setProfile(null);
+          setLoading(false);
+          return;
+        }
+
+        if (event === 'SIGNED_IN' && newSession?.user) {
+          // Handle pending OAuth role assignment
+          const pendingRole = localStorage.getItem('pending_signup_role');
+          const pendingHospitalId = localStorage.getItem('pending_signup_hospital_id');
+
+          if (pendingRole) {
+            await supabase.from('profiles').update({
+              role: pendingRole,
+              hospital_id: pendingHospitalId || null,
+            }).eq('id', newSession.user.id);
+
+            localStorage.removeItem('pending_signup_role');
+            localStorage.removeItem('pending_signup_hospital_id');
+          }
+        }
 
         if (newSession?.user) {
           await fetchProfile(newSession.user.id);
@@ -86,16 +107,55 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       }
     );
 
+    // 2. Then get initial session
+    supabase.auth.getSession().then(({ data: { session: currentSession }, error: sessionError }) => {
+      if (!isMounted) return;
+      if (sessionError) {
+        console.error('Failed to get session:', sessionError.message);
+        setLoading(false);
+        return;
+      }
+      setSession(currentSession);
+      setUser(currentSession?.user ?? null);
+
+      if (currentSession?.user) {
+        fetchProfile(currentSession.user.id).finally(() => {
+          if (isMounted) setLoading(false);
+        });
+      } else {
+        setLoading(false);
+      }
+    }).catch((err) => {
+      if (isMounted) {
+        console.error('Unexpected error getting session:', err);
+        setLoading(false);
+      }
+    });
+
     return () => {
+      isMounted = false;
       subscription.unsubscribe();
     };
   }, [fetchProfile]);
 
   const signOut = useCallback(async () => {
-    await supabase.auth.signOut();
-    setUser(null);
-    setSession(null);
-    setProfile(null);
+    if (!supabase) {
+      // Demo mode: manual cleanup
+      setUser(null);
+      setSession(null);
+      setProfile(null);
+      return;
+    }
+
+    const { error } = await supabase.auth.signOut();
+    if (error) {
+      console.error('Sign out failed:', error.message);
+      // Even on failure, clear local state for UX
+      setUser(null);
+      setSession(null);
+      setProfile(null);
+    }
+    // On success, onAuthStateChange SIGNED_OUT event handles state cleanup
   }, []);
 
   return (

--- a/src/hooks/useBeds.ts
+++ b/src/hooks/useBeds.ts
@@ -1,0 +1,118 @@
+import { useState, useEffect, useCallback } from 'react';
+import { supabase } from '../lib/supabase';
+import { useAuth } from '../contexts/AuthContext';
+import { mockBeds, type BedInfo } from '../mocks/bedData';
+
+interface UseBedsReturn {
+  beds: BedInfo[];
+  loading: boolean;
+  error: string | null;
+  updateBedStatus: (bedId: string, status: BedInfo['status']) => void;
+}
+
+export function useBeds(): UseBedsReturn {
+  const { profile } = useAuth();
+  const [beds, setBeds] = useState<BedInfo[]>(mockBeds);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!supabase || !profile?.hospital_id) return;
+
+    let cancelled = false;
+
+    const fetchBeds = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const { data, error: fetchError } = await supabase!
+          .from('beds')
+          .select(`
+            id, section, number, status, last_cleaned, notes,
+            patients!bed_id (name, id, admission_time, diagnosis)
+          `)
+          .eq('hospital_id', profile.hospital_id!)
+          .order('section')
+          .order('number');
+
+        if (fetchError) throw fetchError;
+        if (cancelled) return;
+
+        const mapped: BedInfo[] = (data ?? []).map((bed: Record<string, unknown>) => {
+          const patients = bed.patients as Record<string, unknown>[] | null;
+          const patient = patients?.[0];
+          return {
+            id: `${bed.section}-${bed.number}`,
+            section: bed.section as string,
+            number: bed.number as string,
+            status: bed.status as BedInfo['status'],
+            patient: patient
+              ? {
+                  name: patient.name as string,
+                  id: (patient.id as string).slice(0, 8),
+                  admissionTime: new Date(patient.admission_time as string).toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' }),
+                  diagnosis: patient.diagnosis as string,
+                }
+              : undefined,
+            equipment: [],
+            lastCleaned: bed.last_cleaned
+              ? new Date(bed.last_cleaned as string).toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' })
+              : '-',
+            notes: bed.notes as string | undefined,
+            _supabaseId: bed.id as string,
+          };
+        });
+
+        setBeds(mapped);
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to fetch beds');
+          setBeds(mockBeds);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    fetchBeds();
+
+    // Realtime subscription
+    const channel = supabase!
+      .channel('beds-changes')
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'beds' }, () => {
+        fetchBeds();
+      })
+      .subscribe();
+
+    return () => {
+      cancelled = true;
+      channel.unsubscribe();
+    };
+  }, [profile?.hospital_id]);
+
+  const updateBedStatus = useCallback(
+    (bedId: string, status: BedInfo['status']) => {
+      const prevBeds = beds;
+      setBeds(prev => prev.map(b => (b.id === bedId ? { ...b, status } : b)));
+
+      if (supabase && profile?.hospital_id) {
+        const [section, number] = bedId.split('-');
+        supabase
+          .from('beds')
+          .update({ status })
+          .eq('hospital_id', profile.hospital_id)
+          .eq('section', section)
+          .eq('number', number)
+          .then(({ error: err }) => {
+            if (err) {
+              console.error('Bed status update failed:', err);
+              setBeds(prevBeds);
+            }
+          });
+      }
+    },
+    [beds, profile?.hospital_id],
+  );
+
+  return { beds, loading, error, updateBedStatus };
+}

--- a/src/hooks/useEquipment.ts
+++ b/src/hooks/useEquipment.ts
@@ -1,0 +1,107 @@
+import { useState, useEffect, useCallback } from 'react';
+import { supabase } from '../lib/supabase';
+import { useAuth } from '../contexts/AuthContext';
+import { mockEquipment, type Equipment } from '../mocks/equipmentData';
+
+interface UseEquipmentReturn {
+  equipment: Equipment[];
+  loading: boolean;
+  error: string | null;
+  updateEquipmentStatus: (equipmentId: string, status: Equipment['status']) => void;
+}
+
+export function useEquipment(): UseEquipmentReturn {
+  const { profile } = useAuth();
+  const [equipment, setEquipment] = useState<Equipment[]>(mockEquipment);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!supabase || !profile?.hospital_id) return;
+
+    let cancelled = false;
+
+    const fetchEquipment = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const { data, error: fetchError } = await supabase!
+          .from('equipment')
+          .select('*')
+          .eq('hospital_id', profile.hospital_id!)
+          .order('name');
+
+        if (fetchError) throw fetchError;
+        if (cancelled) return;
+
+        const mapped: Equipment[] = (data ?? []).map((e: Record<string, unknown>) => ({
+          id: (e.id as string).slice(0, 5).toUpperCase(),
+          name: e.name as string,
+          type: e.type as Equipment['type'],
+          model: (e.model as string) ?? '-',
+          manufacturer: (e.manufacturer as string) ?? '-',
+          status: e.status as Equipment['status'],
+          location: (e.location as string) ?? '-',
+          lastMaintenance: (e.last_maintenance as string) ?? '-',
+          nextMaintenance: (e.next_maintenance as string) ?? '-',
+          batteryLevel: e.battery_level as number | undefined,
+          usageHours: (e.usage_hours as number) ?? 0,
+          alerts: (e.alerts as string[]) ?? [],
+          assignedTo: undefined,
+          notes: e.notes as string | undefined,
+          _supabaseId: e.id as string,
+        }));
+
+        setEquipment(mapped);
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to fetch equipment');
+          setEquipment(mockEquipment);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    fetchEquipment();
+
+    const channel = supabase!
+      .channel('equipment-changes')
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'equipment' }, () => {
+        fetchEquipment();
+      })
+      .subscribe();
+
+    return () => {
+      cancelled = true;
+      channel.unsubscribe();
+    };
+  }, [profile?.hospital_id]);
+
+  const updateEquipmentStatus = useCallback(
+    (equipmentId: string, status: Equipment['status']) => {
+      const prevEquipment = equipment;
+      setEquipment(prev => prev.map(e => (e.id === equipmentId ? { ...e, status } : e)));
+
+      if (supabase) {
+        const item = equipment.find(e => e.id === equipmentId);
+        const supabaseId = (item as Record<string, unknown> | undefined)?._supabaseId as string | undefined;
+        if (supabaseId) {
+          supabase
+            .from('equipment')
+            .update({ status })
+            .eq('id', supabaseId)
+            .then(({ error: err }) => {
+              if (err) {
+                console.error('Equipment status update failed:', err);
+                setEquipment(prevEquipment);
+              }
+            });
+        }
+      }
+    },
+    [equipment],
+  );
+
+  return { equipment, loading, error, updateEquipmentStatus };
+}

--- a/src/hooks/usePatients.ts
+++ b/src/hooks/usePatients.ts
@@ -1,0 +1,116 @@
+import { useState, useEffect, useCallback } from 'react';
+import { supabase } from '../lib/supabase';
+import { useAuth } from '../contexts/AuthContext';
+import { mockPatients, type Patient } from '../mocks/patientData';
+
+interface UsePatientsReturn {
+  patients: Patient[];
+  loading: boolean;
+  error: string | null;
+  updatePatientStatus: (patientId: string, status: Patient['status']) => void;
+}
+
+export function usePatients(): UsePatientsReturn {
+  const { profile } = useAuth();
+  const [patients, setPatients] = useState<Patient[]>(mockPatients);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!supabase || !profile?.hospital_id) return;
+
+    let cancelled = false;
+
+    const fetchPatients = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const { data, error: fetchError } = await supabase!
+          .from('patients')
+          .select(`
+            id, name, age, gender, diagnosis, severity, status,
+            admission_time, vitals,
+            beds!bed_id (section, number)
+          `)
+          .eq('hospital_id', profile.hospital_id!)
+          .order('admission_time', { ascending: false });
+
+        if (fetchError) throw fetchError;
+        if (cancelled) return;
+
+        const mapped: Patient[] = (data ?? []).map((p: Record<string, unknown>) => {
+          const vitals = (p.vitals ?? {}) as Record<string, unknown>;
+          const bed = p.beds as Record<string, unknown> | null;
+          return {
+            id: (p.id as string).slice(0, 8).toUpperCase(),
+            name: p.name as string,
+            age: (p.age as number) ?? 0,
+            gender: (p.gender as string) ?? '-',
+            diagnosis: (p.diagnosis as string) ?? '-',
+            severity: p.severity as Patient['severity'],
+            admissionTime: new Date(p.admission_time as string).toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' }),
+            bed: bed ? `${bed.section}-${bed.number}` : '-',
+            vitals: {
+              heartRate: (vitals.heartRate as number) ?? 0,
+              bloodPressure: (vitals.bloodPressure as string) ?? '-',
+              temperature: (vitals.temperature as number) ?? 0,
+              oxygenSaturation: (vitals.oxygenSaturation as number) ?? 0,
+            },
+            status: p.status as Patient['status'],
+            _supabaseId: p.id as string,
+          };
+        });
+
+        setPatients(mapped);
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to fetch patients');
+          setPatients(mockPatients);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    fetchPatients();
+
+    const channel = supabase!
+      .channel('patients-changes')
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'patients' }, () => {
+        fetchPatients();
+      })
+      .subscribe();
+
+    return () => {
+      cancelled = true;
+      channel.unsubscribe();
+    };
+  }, [profile?.hospital_id]);
+
+  const updatePatientStatus = useCallback(
+    (patientId: string, status: Patient['status']) => {
+      const prevPatients = patients;
+      setPatients(prev => prev.map(p => (p.id === patientId ? { ...p, status } : p)));
+
+      if (supabase && profile?.hospital_id) {
+        const patient = patients.find(p => p.id === patientId);
+        const supabaseId = (patient as Record<string, unknown> | undefined)?._supabaseId as string | undefined;
+        if (supabaseId) {
+          supabase
+            .from('patients')
+            .update({ status })
+            .eq('id', supabaseId)
+            .then(({ error: err }) => {
+              if (err) {
+                console.error('Patient status update failed:', err);
+                setPatients(prevPatients);
+              }
+            });
+        }
+      }
+    },
+    [patients, profile?.hospital_id],
+  );
+
+  return { patients, loading, error, updatePatientStatus };
+}

--- a/src/hooks/useRequests.ts
+++ b/src/hooks/useRequests.ts
@@ -1,0 +1,154 @@
+import { useState, useEffect, useCallback } from 'react';
+import { supabase } from '../lib/supabase';
+import { useAuth } from '../contexts/AuthContext';
+import { generateMockRequests, type MockRequest } from '../components/common/models';
+
+interface CreateRequestData {
+  symptom: string;
+  severity: number;
+  priority: 'emergency' | 'urgent' | 'normal';
+  patientName?: string;
+  patientAge?: number;
+  patientGender?: string;
+  vitals?: Record<string, unknown>;
+  locationText?: string;
+  notes?: string;
+}
+
+interface UseRequestsReturn {
+  requests: MockRequest[];
+  loading: boolean;
+  error: string | null;
+  updateRequestStatus: (requestId: string, status: MockRequest['status']) => void;
+  createRequest: (data: CreateRequestData) => Promise<boolean>;
+}
+
+export function useRequests(): UseRequestsReturn {
+  const { user, profile } = useAuth();
+  const [requests, setRequests] = useState<MockRequest[]>(() => generateMockRequests());
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!supabase || !user) return;
+
+    let cancelled = false;
+
+    const fetchRequests = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        let query = supabase!.from('requests').select('*');
+
+        if (profile?.role === 'hospital_staff' && profile.hospital_id) {
+          query = query.eq('hospital_id', profile.hospital_id);
+        } else if (profile?.role === 'paramedic') {
+          query = query.eq('paramedic_id', user.id);
+        }
+
+        const { data, error: fetchError } = await query.order('requested_at', { ascending: false });
+        if (fetchError) throw fetchError;
+        if (cancelled) return;
+
+        const mapped: MockRequest[] = (data ?? []).map((r: Record<string, unknown>) => ({
+          id: `RQ-${(r.id as string).slice(0, 4).toUpperCase()}`,
+          time: new Date(r.requested_at as string),
+          severity: r.severity as number,
+          distanceKm: Number(r.distance_km ?? 0),
+          symptom: r.symptom as string,
+          status: dbStatusToFrontend(r.status as string),
+          patientAge: r.patient_age ? `${r.patient_age}세` : undefined,
+          allergies: (r.allergies as string[] | null)?.length ? (r.allergies as string[]) : undefined,
+          eta: r.eta_minutes as number | undefined,
+          _supabaseId: r.id as string,
+        }));
+
+        setRequests(mapped);
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to fetch requests');
+          setRequests(generateMockRequests());
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    fetchRequests();
+
+    const channel = supabase!
+      .channel('requests-changes')
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'requests' }, () => {
+        fetchRequests();
+      })
+      .subscribe();
+
+    return () => {
+      cancelled = true;
+      channel.unsubscribe();
+    };
+  }, [user, profile?.hospital_id, profile?.role]);
+
+  const updateRequestStatus = useCallback(
+    (requestId: string, status: MockRequest['status']) => {
+      const prevRequests = requests;
+      setRequests(prev => prev.map(r => (r.id === requestId ? { ...r, status } : r)));
+
+      if (supabase) {
+        const item = requests.find(r => r.id === requestId);
+        const supabaseId = (item as Record<string, unknown> | undefined)?._supabaseId as string | undefined;
+        if (supabaseId) {
+          const dbStatus = status === 'enRoute' ? 'en_route' : status;
+          supabase
+            .from('requests')
+            .update({ status: dbStatus, ...(status === 'matched' ? { matched_at: new Date().toISOString() } : {}) })
+            .eq('id', supabaseId)
+            .then(({ error: err }) => {
+              if (err) {
+                console.error('Request status update failed:', err);
+                setRequests(prevRequests);
+              }
+            });
+        }
+      }
+    },
+    [requests],
+  );
+
+  const createRequest = useCallback(
+    async (data: CreateRequestData): Promise<boolean> => {
+      if (!supabase || !user) return true; // Demo mode: always succeeds
+
+      try {
+        const { error: insertError } = await supabase.from('requests').insert({
+          paramedic_id: user.id,
+          symptom: data.symptom,
+          severity: data.severity,
+          priority: data.priority,
+          patient_name: data.patientName,
+          patient_age: data.patientAge,
+          patient_gender: data.patientGender,
+          vitals: data.vitals ?? {},
+          location_text: data.locationText,
+          notes: data.notes,
+        });
+
+        if (insertError) throw insertError;
+        return true;
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to create request');
+        return false;
+      }
+    },
+    [user],
+  );
+
+  return { requests, loading, error, updateRequestStatus, createRequest };
+}
+
+function dbStatusToFrontend(status: string): MockRequest['status'] {
+  switch (status) {
+    case 'en_route': return 'enRoute';
+    default: return status as MockRequest['status'];
+  }
+}

--- a/src/hooks/useStaff.ts
+++ b/src/hooks/useStaff.ts
@@ -1,0 +1,107 @@
+import { useState, useEffect, useCallback } from 'react';
+import { supabase } from '../lib/supabase';
+import { useAuth } from '../contexts/AuthContext';
+import { mockStaff, type StaffMember } from '../mocks/staffData';
+
+interface UseStaffReturn {
+  staff: StaffMember[];
+  loading: boolean;
+  error: string | null;
+  updateStaffStatus: (staffId: string, status: StaffMember['status']) => void;
+}
+
+// DB uses underscores for enum values, frontend uses hyphens
+const dbStatusToFrontend = (s: string): StaffMember['status'] =>
+  s.replace('_', '-') as StaffMember['status'];
+
+const frontendStatusToDb = (s: string): string =>
+  s.replace('-', '_');
+
+export function useStaff(): UseStaffReturn {
+  const { profile } = useAuth();
+  const [staff, setStaff] = useState<StaffMember[]>(mockStaff);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!supabase || !profile?.hospital_id) return;
+
+    let cancelled = false;
+
+    const fetchStaff = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const { data, error: fetchError } = await supabase!
+          .from('staff')
+          .select('*')
+          .eq('hospital_id', profile.hospital_id!)
+          .order('name');
+
+        if (fetchError) throw fetchError;
+        if (cancelled) return;
+
+        const mapped: StaffMember[] = (data ?? []).map((s: Record<string, unknown>) => ({
+          id: (s.id as string).slice(0, 6).toUpperCase(),
+          name: s.name as string,
+          role: s.role as StaffMember['role'],
+          department: (s.department as string) ?? '-',
+          shift: s.shift as StaffMember['shift'],
+          status: dbStatusToFrontend(s.status as string),
+          phone: (s.phone as string) ?? '-',
+          email: (s.email as string) ?? '-',
+          specialization: s.specialization as string | undefined,
+          yearsOfExperience: (s.years_of_experience as number) ?? 0,
+          currentLocation: (s.current_location as string) ?? '-',
+          shiftStart: s.shift_start ? (s.shift_start as string).slice(0, 5) : '-',
+          shiftEnd: s.shift_end ? (s.shift_end as string).slice(0, 5) : '-',
+          certifications: (s.certifications as string[]) ?? [],
+          emergencyContact: (s.emergency_contact as string) ?? '-',
+          _supabaseId: s.id as string,
+        }));
+
+        setStaff(mapped);
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to fetch staff');
+          setStaff(mockStaff);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    fetchStaff();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [profile?.hospital_id]);
+
+  const updateStaffStatus = useCallback(
+    (staffId: string, status: StaffMember['status']) => {
+      const prevStaff = staff;
+      setStaff(prev => prev.map(s => (s.id === staffId ? { ...s, status } : s)));
+
+      if (supabase) {
+        const member = staff.find(s => s.id === staffId);
+        const supabaseId = (member as Record<string, unknown> | undefined)?._supabaseId as string | undefined;
+        if (supabaseId) {
+          supabase
+            .from('staff')
+            .update({ status: frontendStatusToDb(status) })
+            .eq('id', supabaseId)
+            .then(({ error: err }) => {
+              if (err) {
+                console.error('Staff status update failed:', err);
+                setStaff(prevStaff);
+              }
+            });
+        }
+      }
+    },
+    [staff],
+  );
+
+  return { staff, loading, error, updateStaffStatus };
+}


### PR DESCRIPTION
## Summary
- **#40**: `useRequests.updateRequestStatus`와 `usePatients.updatePatientStatus`에 Supabase `.update()` 호출 추가 + 실패 시 낙관적 업데이트 롤백. `PatientDetails` 저장 버튼에 실제 DB 저장 로직 구현. 상태 업데이트 버튼의 고정 문자열 "updated" 대신 Select 드롭다운으로 교체. `useBeds`, `useStaff`, `useEquipment`의 낙관적 업데이트에 실패 시 롤백 추가.
- **#42**: Google OAuth 회원가입 시 선택한 role/hospital_id를 localStorage에 임시 저장하고, AuthContext의 `onAuthStateChange` SIGNED_IN 이벤트에서 profiles 테이블 업데이트.
- **#43**: AuthContext 초기화 경쟁 조건 해결 (리스너 먼저 등록 후 getSession 호출), getSession 에러 처리 추가, signOut 에러 처리 + 로컬 상태 정리, Demo 모드 분기 추가.

## Changed files
- `src/hooks/useRequests.ts` (new)
- `src/hooks/usePatients.ts` (new)
- `src/hooks/useBeds.ts` (new)
- `src/hooks/useStaff.ts` (new)
- `src/hooks/useEquipment.ts` (new)
- `src/components/hospital/PatientDetails.tsx` (modified)
- `src/components/auth/SignupPage.tsx` (modified)
- `src/contexts/AuthContext.tsx` (modified)

## Test plan
- [ ] 요청 수락 후 새로고침 -> 상태 유지 확인
- [ ] 환자 상태 변경 후 새로고침 -> 상태 유지 확인
- [ ] PatientDetails 저장 버튼 -> DB에 notes 업데이트 확인
- [ ] Google OAuth 가입 시 role이 정상 반영되는지 확인
- [ ] 앱 초기 로드 시 무한 로딩 없이 정상 작동 확인
- [ ] 네트워크 차단 상태에서 상태 변경 시 롤백 확인

Closes #40, #42, #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)