### PR TITLE
fix: [batch-c] 에러 처리 개선, 타입-스키마 불일치 수정 (#44,#45)

### DIFF
--- a/src/components/common/__tests__/models.test.ts
+++ b/src/components/common/__tests__/models.test.ts
@@ -35,7 +35,7 @@ describe('generateMockRequests', () => {
   });
 
   it('status should be one of the valid values', () => {
-    const validStatuses = ['pending', 'matched', 'enRoute', 'completed'];
+    const validStatuses = ['pending', 'matched', 'enRoute', 'completed', 'cancelled'];
     const requests = generateMockRequests();
     for (const req of requests) {
       expect(validStatuses).toContain(req.status);

--- a/src/components/common/models.ts
+++ b/src/components/common/models.ts
@@ -4,10 +4,11 @@ export interface MockRequest {
   severity: number; // 1(경미) ~ 5(중증)
   distanceKm: number;
   symptom: string;
-  status: 'pending' | 'matched' | 'enRoute' | 'completed';
+  status: 'pending' | 'matched' | 'enRoute' | 'completed' | 'cancelled';
   patientAge?: string;
   allergies?: string[];
   eta?: number; // minutes
+  _supabaseId?: string;  // Supabase에서 fetch한 경우에만 존재
 }
 
 export interface MockHospital {
@@ -20,12 +21,13 @@ export interface MockHospital {
   distanceKm: number;
   contact?: string;
   avgWaitTime?: number; // minutes
+  _supabaseId?: string;  // Supabase에서 fetch한 경우에만 존재
 }
 
 // 목 데이터 생성
 export const generateMockRequests = (): MockRequest[] => {
   const symptoms = ['흉통', '호흡곤란', '외상', '복통', '두통', '발열', '의식잃음', '심정지'];
-  const statuses: Array<'pending' | 'matched' | 'enRoute' | 'completed'> = ['pending', 'matched', 'enRoute', 'completed'];
+  const statuses: Array<'pending' | 'matched' | 'enRoute' | 'completed' | 'cancelled'> = ['pending', 'matched', 'enRoute', 'completed', 'cancelled'];
   
   return Array.from({ length: 12 }, (_, i) => ({
     id: `RQ-${String(1001 + i).padStart(4, '0')}`,

--- a/src/components/hospital/BedManagement.tsx
+++ b/src/components/hospital/BedManagement.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
 import { Button } from "../ui/button";
 import { Badge } from "../ui/badge";
@@ -10,14 +10,16 @@ import { Separator } from "../ui/separator";
 import { Progress } from "../ui/progress";
 import { toast } from "sonner";
 import { getBedStatusText } from "../../utils/statusHelpers";
-import { mockBeds, type BedInfo } from "@/mocks/bedData";
+import { useBeds } from "../../hooks/useBeds";
+import type { BedInfo } from "@/mocks/bedData";
 import {
   Bed,
   Plus,
   Settings,
   User,
   Calendar,
-  Clock
+  Clock,
+  Loader2
 } from 'lucide-react';
 
 
@@ -32,11 +34,17 @@ const getBedStatusBadgeClass = (status: string): string => {
 };
 
 export function BedManagement() {
-  const [beds, setBeds] = useState<BedInfo[]>(mockBeds);
+  const { beds, loading, error, updateBedStatus } = useBeds();
   const [selectedSection, setSelectedSection] = useState<string>('all');
   const [selectedStatus, setSelectedStatus] = useState<string>('all');
   const [selectedBed, setSelectedBed] = useState<BedInfo | null>(null);
   const [dialogOpen, setDialogOpen] = useState(false);
+
+  useEffect(() => {
+    if (error) {
+      toast.error(error);
+    }
+  }, [error]);
 
   const sections = ['A', 'B', 'C'];
 
@@ -57,9 +65,26 @@ export function BedManagement() {
   const occupancyRate = bedStats.total > 0 ? Math.round((bedStats.occupied / bedStats.total) * 100) : 0;
 
   const handleBedStatusChange = (bedId: string, newStatus: string) => {
-    setBeds(prev => prev.map(b => b.id === bedId ? { ...b, status: newStatus as BedInfo['status'] } : b));
+    updateBedStatus(bedId, newStatus as BedInfo['status']);
     toast.success(`병상 ${bedId}의 상태가 ${getBedStatusText(newStatus)}로 변경되었습니다.`);
   };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <Loader2 className="animate-spin text-muted-foreground" size={32} />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex flex-col items-center justify-center h-64 text-muted-foreground">
+        <p className="text-lg font-medium">데이터를 불러오지 못했습니다</p>
+        <p className="text-sm mt-1">{error}</p>
+      </div>
+    );
+  }
 
   const handleAssignPatient = (bedId: string) => {
     toast.success(`병상 ${bedId}에 환자 배정 폼이 열렸습니다.`);

--- a/src/components/hospital/EquipmentStatus.tsx
+++ b/src/components/hospital/EquipmentStatus.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
 import { Button } from "../ui/button";
 import { Badge } from "../ui/badge";
@@ -11,7 +11,8 @@ import { Progress } from "../ui/progress";
 import { Separator } from "../ui/separator";
 import { toast } from "sonner";
 import { getEquipmentStatusText, getEquipmentTypeText } from "../../utils/statusHelpers";
-import { mockEquipment, type Equipment } from "@/mocks/equipmentData";
+import { useEquipment } from "../../hooks/useEquipment";
+import type { Equipment } from "@/mocks/equipmentData";
 import {
   Search,
   Plus,
@@ -25,7 +26,8 @@ import {
   Activity,
   Zap,
   Monitor,
-  Droplets
+  Droplets,
+  Loader2
 } from 'lucide-react';
 
 const getTypeIcon = (type: string) => {
@@ -63,12 +65,18 @@ const getBatteryTextClass = (level: number): string => {
 };
 
 export function EquipmentStatus() {
-  const [equipment, setEquipment] = useState<Equipment[]>(mockEquipment);
+  const { equipment, loading, error, updateEquipmentStatus } = useEquipment();
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedType, setSelectedType] = useState<string>('all');
   const [selectedStatus, setSelectedStatus] = useState<string>('all');
   const [selectedEquipment, setSelectedEquipment] = useState<Equipment | null>(null);
   const [dialogOpen, setDialogOpen] = useState(false);
+
+  useEffect(() => {
+    if (error) {
+      toast.error(error);
+    }
+  }, [error]);
 
   const filteredEquipment = equipment.filter(item => {
     const matchesSearch = item.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
@@ -97,13 +105,30 @@ export function EquipmentStatus() {
   };
 
   const handleStatusChange = (equipmentId: string, newStatus: string) => {
-    setEquipment(prev => prev.map(e => e.id === equipmentId ? { ...e, status: newStatus as Equipment['status'] } : e));
+    updateEquipmentStatus(equipmentId, newStatus as Equipment['status']);
     toast.success(`장비 ${equipmentId}의 상태가 ${getEquipmentStatusText(newStatus)}로 변경되었습니다.`);
   };
 
   const handleEmergencyAlert = (equipmentId: string) => {
     toast.error(`장비 ${equipmentId}에서 응급 알림이 발생했습니다!`);
   };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <Loader2 className="animate-spin text-muted-foreground" size={32} />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex flex-col items-center justify-center h-64 text-muted-foreground">
+        <p className="text-lg font-medium">데이터를 불러오지 못했습니다</p>
+        <p className="text-sm mt-1">{error}</p>
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-6">

--- a/src/components/hospital/HospitalDashboard.tsx
+++ b/src/components/hospital/HospitalDashboard.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
 import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
@@ -6,7 +6,8 @@ import { Switch } from "../ui/switch";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../ui/table";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from "../ui/dialog";
 import { InfoCard } from "../common/InfoCard";
-import { generateMockRequests, MockRequest } from "../common/models";
+import { useRequests } from "../../hooks/useRequests";
+import type { MockRequest } from "../common/models";
 import {
   Building2,
   Users,
@@ -20,7 +21,8 @@ import {
   Heart,
   Activity,
   Brain,
-  TrendingUp
+  TrendingUp,
+  Loader2
 } from 'lucide-react';
 import { toast } from "sonner";
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, PieChart, Pie, Cell } from 'recharts';
@@ -33,8 +35,14 @@ const recentAlerts = [
 
 export function HospitalDashboard() {
   const [accepting, setAccepting] = useState(true);
-  const [requests, setRequests] = useState(generateMockRequests());
+  const { requests, loading: requestsLoading, error: requestsError, updateRequestStatus } = useRequests();
   const [selectedSeverity, setSelectedSeverity] = useState('all');
+
+  useEffect(() => {
+    if (requestsError) {
+      toast.error(requestsError);
+    }
+  }, [requestsError]);
 
   const handleAcceptingToggle = (isAccepting: boolean) => {
     setAccepting(isAccepting);
@@ -42,11 +50,7 @@ export function HospitalDashboard() {
   };
 
   const handleRequestAction = (requestId: string, action: 'accept' | 'hold') => {
-    setRequests(prev => prev.map(req =>
-      req.id === requestId
-        ? { ...req, status: action === 'accept' ? 'matched' : 'pending' }
-        : req
-    ));
+    updateRequestStatus(requestId, action === 'accept' ? 'matched' : 'pending');
     toast(action === 'accept' ? "요청을 수락했습니다" : "요청을 보류했습니다");
   };
 
@@ -110,6 +114,14 @@ export function HospitalDashboard() {
     { name: '보통', value: requests.filter(r => r.severity === 3).length, color: 'var(--chart-4)' },
     { name: '심각', value: requests.filter(r => r.severity >= 4).length, color: 'var(--chart-5)' },
   ];
+
+  if (requestsLoading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <Loader2 className="animate-spin text-muted-foreground" size={32} />
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-6">

--- a/src/components/hospital/PatientDetails.tsx
+++ b/src/components/hospital/PatientDetails.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
 import { Button } from "../ui/button";
 import { Badge } from "../ui/badge";
@@ -11,7 +11,8 @@ import { Textarea } from "../ui/textarea";
 import { Separator } from "../ui/separator";
 import { toast } from "sonner";
 import { getSeverityText, getPatientStatusText } from "../../utils/statusHelpers";
-import { mockPatients, type Patient } from "@/mocks/patientData";
+import { usePatients } from "../../hooks/usePatients";
+import type { Patient } from "@/mocks/patientData";
 import {
   Search,
   UserPlus,
@@ -22,7 +23,8 @@ import {
   Thermometer,
   Droplets,
   Activity,
-  Users
+  Users,
+  Loader2
 } from 'lucide-react';
 
 
@@ -46,12 +48,18 @@ const getPatientStatusBadgeClass = (status: string): string => {
 };
 
 export function PatientDetails() {
-  const [patients, setPatients] = useState<Patient[]>(mockPatients);
+  const { patients, loading, error, updatePatientStatus } = usePatients();
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedPatient, setSelectedPatient] = useState<Patient | null>(null);
   const [dialogOpen, setDialogOpen] = useState(false);
   const [filterSeverity, setFilterSeverity] = useState<string>('all');
   const [filterStatus, setFilterStatus] = useState<string>('all');
+
+  useEffect(() => {
+    if (error) {
+      toast.error(error);
+    }
+  }, [error]);
 
   const filteredPatients = patients.filter(patient => {
     const matchesSearch = patient.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
@@ -72,9 +80,26 @@ export function PatientDetails() {
   };
 
   const handleUpdateStatus = (patientId: string, newStatus: string) => {
-    setPatients(prev => prev.map(p => p.id === patientId ? { ...p, status: newStatus as Patient['status'] } : p));
+    updatePatientStatus(patientId, newStatus as Patient['status']);
     toast.success(`환자 ${patientId}의 상태가 ${newStatus}로 업데이트되었습니다.`);
   };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <Loader2 className="animate-spin text-muted-foreground" size={32} />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex flex-col items-center justify-center h-64 text-muted-foreground">
+        <p className="text-lg font-medium">데이터를 불러오지 못했습니다</p>
+        <p className="text-sm mt-1">{error}</p>
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-6">

--- a/src/components/hospital/StaffManagement.tsx
+++ b/src/components/hospital/StaffManagement.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
 import { Button } from "../ui/button";
 import { Badge } from "../ui/badge";
@@ -12,7 +12,8 @@ import { Avatar, AvatarFallback } from "../ui/avatar";
 import { Separator } from "../ui/separator";
 import { toast } from "sonner";
 import { getRoleText, getStaffStatusText } from "../../utils/statusHelpers";
-import { mockStaff, type StaffMember } from "@/mocks/staffData";
+import { useStaff } from "../../hooks/useStaff";
+import type { StaffMember } from "@/mocks/staffData";
 import {
   Search,
   Plus,
@@ -27,7 +28,8 @@ import {
   Users,
   Stethoscope,
   Activity,
-  Shield
+  Shield,
+  Loader2
 } from 'lucide-react';
 
 
@@ -53,10 +55,10 @@ const getRoleBadgeClass = (role: string): string => {
 
 const getStaffStatusIcon = (status: string) => {
   switch (status) {
-    case 'on-duty': return '\u25CF'; // ●
-    case 'break': return '\u25CB';   // ○
-    case 'off-duty': return '\u2014'; // —
-    case 'emergency': return '\u26A0'; // ⚠
+    case 'on-duty': return '\u25CF'; // filled circle
+    case 'break': return '\u25CB';   // empty circle
+    case 'off-duty': return '\u2014'; // em dash
+    case 'emergency': return '\u26A0'; // warning
     default: return '';
   }
 };
@@ -82,12 +84,18 @@ const getAvatarBgClass = (role: string): string => {
 };
 
 export function StaffManagement() {
-  const [staff, setStaff] = useState<StaffMember[]>(mockStaff);
+  const { staff, loading, error, updateStaffStatus } = useStaff();
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedRole, setSelectedRole] = useState<string>('all');
   const [selectedStatus, setSelectedStatus] = useState<string>('all');
   const [selectedStaff, setSelectedStaff] = useState<StaffMember | null>(null);
   const [dialogOpen, setDialogOpen] = useState(false);
+
+  useEffect(() => {
+    if (error) {
+      toast.error(error);
+    }
+  }, [error]);
 
   const filteredStaff = staff.filter(member => {
     const matchesSearch = member.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
@@ -116,14 +124,31 @@ export function StaffManagement() {
   };
 
   const handleStatusChange = (staffId: string, newStatus: string) => {
-    setStaff(prev => prev.map(s => s.id === staffId ? { ...s, status: newStatus as StaffMember['status'] } : s));
+    updateStaffStatus(staffId, newStatus as StaffMember['status']);
     toast.success(`직원 ${staffId}의 상태가 ${getStaffStatusText(newStatus)}로 변경되었습니다.`);
   };
 
   const handleEmergencyCall = (staffId: string) => {
-    setStaff(prev => prev.map(s => s.id === staffId ? { ...s, status: 'emergency' as StaffMember['status'] } : s));
+    updateStaffStatus(staffId, 'emergency');
     toast.success(`${staffId} 직원에게 응급호출이 발송되었습니다.`);
   };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <Loader2 className="animate-spin text-muted-foreground" size={32} />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex flex-col items-center justify-center h-64 text-muted-foreground">
+        <p className="text-lg font-medium">데이터를 불러오지 못했습니다</p>
+        <p className="text-sm mt-1">{error}</p>
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-6">

--- a/src/components/paramedic/ParamedicDashboard.tsx
+++ b/src/components/paramedic/ParamedicDashboard.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
 import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
@@ -6,7 +6,9 @@ import { Switch } from "../ui/switch";
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger } from "../ui/sheet";
 import { InfoCard } from "../common/InfoCard";
 import { MiniMapPlaceholder } from "../common/MiniMapPlaceholder";
-import { generateMockRequests, generateMockHospitals, MockHospital } from "../common/models";
+import { useHospitals } from "../../hooks/useHospitals";
+import { useRequests } from "../../hooks/useRequests";
+import type { MockHospital } from "../common/models";
 import {
   Ambulance,
   Phone,
@@ -16,7 +18,8 @@ import {
   AlertTriangle,
   CheckCircle2,
   Bed,
-  Route
+  Route,
+  Loader2
 } from 'lucide-react';
 import { toast } from "sonner";
 
@@ -28,8 +31,15 @@ const recentEvents = [
 
 export function ParamedicDashboard() {
   const [isOnline, setIsOnline] = useState(true);
-  const [hospitals] = useState(generateMockHospitals());
-  const [requests] = useState(generateMockRequests());
+  const { hospitals, loading: hospitalsLoading, error: hospitalsError } = useHospitals();
+  const { requests, loading: requestsLoading, error: requestsError } = useRequests();
+
+  useEffect(() => {
+    if (hospitalsError) toast.error(hospitalsError);
+    if (requestsError) toast.error(requestsError);
+  }, [hospitalsError, requestsError]);
+
+  const isLoading = hospitalsLoading || requestsLoading;
 
   const handleStatusToggle = (online: boolean) => {
     setIsOnline(online);
@@ -60,6 +70,14 @@ export function ParamedicDashboard() {
       default: return 'border-l-4 border-l-gray-500 bg-muted/50';
     }
   };
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <Loader2 className="animate-spin text-muted-foreground" size={32} />
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-6">

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -7,7 +7,7 @@ export type UserRole = 'hospital_staff' | 'paramedic';
 export interface UserProfile {
   role: UserRole;
   hospital_id: string | null;
-  display_name: string | null;
+  display_name: string;
 }
 
 interface AuthContextType {
@@ -47,10 +47,15 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         return;
       }
 
+      const validRoles: UserRole[] = ['hospital_staff', 'paramedic'];
+      const role = validRoles.includes(data.role as UserRole)
+        ? (data.role as UserRole)
+        : 'paramedic'; // 안전한 기본값
+
       setProfile({
-        role: data.role as UserRole,
+        role,
         hospital_id: data.hospital_id,
-        display_name: data.display_name,
+        display_name: data.display_name ?? '',
       });
     } catch (err) {
       console.error('Unexpected error fetching profile:', err);

--- a/src/hooks/useBeds.ts
+++ b/src/hooks/useBeds.ts
@@ -1,0 +1,114 @@
+import { useState, useEffect, useCallback } from 'react';
+import { supabase } from '../lib/supabase';
+import { useAuth } from '../contexts/AuthContext';
+import { mockBeds, type BedInfo } from '../mocks/bedData';
+
+interface UseBedsReturn {
+  beds: BedInfo[];
+  loading: boolean;
+  error: string | null;
+  updateBedStatus: (bedId: string, status: BedInfo['status']) => void;
+}
+
+export function useBeds(): UseBedsReturn {
+  const { profile } = useAuth();
+  const [beds, setBeds] = useState<BedInfo[]>(mockBeds);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!profile?.hospital_id) return;
+
+    let cancelled = false;
+
+    const fetchBeds = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const { data, error: fetchError } = await supabase
+          .from('beds')
+          .select(`
+            id, section, number, status, last_cleaned, notes,
+            patients!bed_id (name, id, admission_time, diagnosis)
+          `)
+          .eq('hospital_id', profile.hospital_id!)
+          .order('section')
+          .order('number');
+
+        if (fetchError) throw fetchError;
+        if (cancelled) return;
+
+        const mapped: BedInfo[] = (data ?? []).map((bed: Record<string, unknown>) => {
+          const patients = bed.patients as Record<string, unknown>[] | null;
+          const patient = patients?.[0];
+          return {
+            id: `${bed.section}-${bed.number}`,
+            section: bed.section as string,
+            number: bed.number as string,
+            status: bed.status as BedInfo['status'],
+            patient: patient
+              ? {
+                  name: patient.name as string,
+                  id: (patient.id as string).slice(0, 8),
+                  admissionTime: new Date(patient.admission_time as string).toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' }),
+                  diagnosis: patient.diagnosis as string,
+                }
+              : undefined,
+            equipment: [],
+            lastCleaned: bed.last_cleaned
+              ? new Date(bed.last_cleaned as string).toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' })
+              : '-',
+            notes: bed.notes as string | undefined,
+            _supabaseId: bed.id as string,
+          };
+        });
+
+        setBeds(mapped);
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to fetch beds');
+          setBeds(mockBeds);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    fetchBeds();
+
+    // Realtime subscription
+    const channel = supabase
+      .channel('beds-changes')
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'beds' }, () => {
+        fetchBeds();
+      })
+      .subscribe();
+
+    return () => {
+      cancelled = true;
+      channel.unsubscribe();
+    };
+  }, [profile?.hospital_id]);
+
+  const updateBedStatus = useCallback(
+    (bedId: string, status: BedInfo['status']) => {
+      setBeds(prev => prev.map(b => (b.id === bedId ? { ...b, status } : b)));
+
+      if (profile?.hospital_id) {
+        const [section, number] = bedId.split('-');
+        supabase
+          .from('beds')
+          .update({ status })
+          .eq('hospital_id', profile.hospital_id)
+          .eq('section', section)
+          .eq('number', number)
+          .then(({ error: err }) => {
+            if (err) console.error('Bed status update failed:', err);
+          });
+      }
+    },
+    [profile?.hospital_id],
+  );
+
+  return { beds, loading, error, updateBedStatus };
+}

--- a/src/hooks/useEquipment.ts
+++ b/src/hooks/useEquipment.ts
@@ -1,0 +1,101 @@
+import { useState, useEffect, useCallback } from 'react';
+import { supabase } from '../lib/supabase';
+import { useAuth } from '../contexts/AuthContext';
+import { mockEquipment, type Equipment } from '../mocks/equipmentData';
+
+interface UseEquipmentReturn {
+  equipment: Equipment[];
+  loading: boolean;
+  error: string | null;
+  updateEquipmentStatus: (equipmentId: string, status: Equipment['status']) => void;
+}
+
+export function useEquipment(): UseEquipmentReturn {
+  const { profile } = useAuth();
+  const [equipment, setEquipment] = useState<Equipment[]>(mockEquipment);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!profile?.hospital_id) return;
+
+    let cancelled = false;
+
+    const fetchEquipment = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const { data, error: fetchError } = await supabase
+          .from('equipment')
+          .select('*')
+          .eq('hospital_id', profile.hospital_id!)
+          .order('name');
+
+        if (fetchError) throw fetchError;
+        if (cancelled) return;
+
+        const mapped: Equipment[] = (data ?? []).map((e: Record<string, unknown>) => ({
+          id: (e.id as string).slice(0, 5).toUpperCase(),
+          name: e.name as string,
+          type: e.type as Equipment['type'],
+          model: (e.model as string) ?? '-',
+          manufacturer: (e.manufacturer as string) ?? '-',
+          status: e.status as Equipment['status'],
+          location: (e.location as string) ?? '-',
+          lastMaintenance: (e.last_maintenance as string) ?? '-',
+          nextMaintenance: (e.next_maintenance as string) ?? '-',
+          batteryLevel: e.battery_level as number | undefined,
+          usageHours: (e.usage_hours as number) ?? 0,
+          alerts: (e.alerts as string[]) ?? [],
+          assignedTo: undefined,
+          notes: e.notes as string | undefined,
+          _supabaseId: e.id as string,
+        }));
+
+        setEquipment(mapped);
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to fetch equipment');
+          setEquipment(mockEquipment);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    fetchEquipment();
+
+    const channel = supabase
+      .channel('equipment-changes')
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'equipment' }, () => {
+        fetchEquipment();
+      })
+      .subscribe();
+
+    return () => {
+      cancelled = true;
+      channel.unsubscribe();
+    };
+  }, [profile?.hospital_id]);
+
+  const updateEquipmentStatus = useCallback(
+    (equipmentId: string, status: Equipment['status']) => {
+      setEquipment(prev => prev.map(e => (e.id === equipmentId ? { ...e, status } : e)));
+
+      const item = equipment.find(e => e.id === equipmentId);
+      const supabaseId = item?._supabaseId;
+      if (supabaseId) {
+        supabase
+          .from('equipment')
+          .update({ status })
+          .eq('id', supabaseId)
+          .then(({ error: err }) => {
+            if (err) console.error('Equipment status update failed:', err);
+          });
+      }
+    },
+    [equipment],
+  );
+
+  return { equipment, loading, error, updateEquipmentStatus };
+}

--- a/src/hooks/useHospitals.ts
+++ b/src/hooks/useHospitals.ts
@@ -1,0 +1,66 @@
+import { useState, useEffect } from 'react';
+import { supabase } from '../lib/supabase';
+import { generateMockHospitals, type MockHospital } from '../components/common/models';
+
+interface UseHospitalsReturn {
+  hospitals: MockHospital[];
+  loading: boolean;
+  error: string | null;
+}
+
+export function useHospitals(): UseHospitalsReturn {
+  const [hospitals, setHospitals] = useState<MockHospital[]>(() => generateMockHospitals());
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const fetchHospitals = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const { data, error: fetchError } = await supabase.rpc('get_hospital_availability');
+        if (fetchError) throw fetchError;
+        if (cancelled) return;
+
+        const mapped: MockHospital[] = (data ?? []).map((h: Record<string, unknown>, i: number) => ({
+          id: `H-${String(i + 1).padStart(3, '0')}`,
+          name: h.hospital_name as string,
+          accepting: h.accepting as boolean,
+          queue: (h.queue as number) ?? 0,
+          beds: Number(h.available_beds ?? 0),
+          specialties: (h.specialties as string[]) ?? [],
+          distanceKm: Math.round((Math.random() * 8 + 0.5) * 10) / 10, // No real geolocation yet
+          contact: h.contact as string | undefined,
+          avgWaitTime: h.avg_wait_time as number | undefined,
+        }));
+
+        setHospitals(mapped);
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to fetch hospitals');
+          setHospitals(generateMockHospitals());
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    fetchHospitals();
+
+    const channel = supabase
+      .channel('hospitals-changes')
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'hospitals' }, () => {
+        fetchHospitals();
+      })
+      .subscribe();
+
+    return () => {
+      cancelled = true;
+      channel.unsubscribe();
+    };
+  }, []);
+
+  return { hospitals, loading, error };
+}

--- a/src/hooks/usePatients.ts
+++ b/src/hooks/usePatients.ts
@@ -1,0 +1,97 @@
+import { useState, useEffect, useCallback } from 'react';
+import { supabase } from '../lib/supabase';
+import { useAuth } from '../contexts/AuthContext';
+import { mockPatients, type Patient } from '../mocks/patientData';
+
+interface UsePatientsReturn {
+  patients: Patient[];
+  loading: boolean;
+  error: string | null;
+  updatePatientStatus: (patientId: string, status: Patient['status']) => void;
+}
+
+export function usePatients(): UsePatientsReturn {
+  const { profile } = useAuth();
+  const [patients, setPatients] = useState<Patient[]>(mockPatients);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!profile?.hospital_id) return;
+
+    let cancelled = false;
+
+    const fetchPatients = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const { data, error: fetchError } = await supabase
+          .from('patients')
+          .select(`
+            id, name, age, gender, diagnosis, severity, status,
+            admission_time, vitals,
+            beds!bed_id (section, number)
+          `)
+          .eq('hospital_id', profile.hospital_id!)
+          .order('admission_time', { ascending: false });
+
+        if (fetchError) throw fetchError;
+        if (cancelled) return;
+
+        const mapped: Patient[] = (data ?? []).map((p: Record<string, unknown>) => {
+          const vitals = (p.vitals ?? {}) as Record<string, unknown>;
+          const bed = p.beds as Record<string, unknown> | null;
+          return {
+            id: (p.id as string).slice(0, 8).toUpperCase(),
+            name: p.name as string,
+            age: (p.age as number) ?? 0,
+            gender: (p.gender as string) ?? '-',
+            diagnosis: (p.diagnosis as string) ?? '-',
+            severity: p.severity as Patient['severity'],
+            admissionTime: new Date(p.admission_time as string).toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' }),
+            bed: bed ? `${bed.section}-${bed.number}` : '-',
+            vitals: {
+              heartRate: (vitals.heartRate as number) ?? 0,
+              bloodPressure: (vitals.bloodPressure as string) ?? '-',
+              temperature: (vitals.temperature as number) ?? 0,
+              oxygenSaturation: (vitals.oxygenSaturation as number) ?? 0,
+            },
+            status: p.status as Patient['status'],
+          };
+        });
+
+        setPatients(mapped);
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to fetch patients');
+          setPatients(mockPatients);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    fetchPatients();
+
+    const channel = supabase
+      .channel('patients-changes')
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'patients' }, () => {
+        fetchPatients();
+      })
+      .subscribe();
+
+    return () => {
+      cancelled = true;
+      channel.unsubscribe();
+    };
+  }, [profile?.hospital_id]);
+
+  const updatePatientStatus = useCallback(
+    (patientId: string, status: Patient['status']) => {
+      setPatients(prev => prev.map(p => (p.id === patientId ? { ...p, status } : p)));
+    },
+    [],
+  );
+
+  return { patients, loading, error, updatePatientStatus };
+}

--- a/src/hooks/useRequests.ts
+++ b/src/hooks/useRequests.ts
@@ -1,0 +1,136 @@
+import { useState, useEffect, useCallback } from 'react';
+import { supabase } from '../lib/supabase';
+import { useAuth } from '../contexts/AuthContext';
+import { generateMockRequests, type MockRequest } from '../components/common/models';
+
+interface CreateRequestData {
+  symptom: string;
+  severity: number;
+  priority: 'emergency' | 'urgent' | 'normal';
+  patientName?: string;
+  patientAge?: number;
+  patientGender?: string;
+  vitals?: Record<string, unknown>;
+  locationText?: string;
+  notes?: string;
+}
+
+interface UseRequestsReturn {
+  requests: MockRequest[];
+  loading: boolean;
+  error: string | null;
+  updateRequestStatus: (requestId: string, status: MockRequest['status']) => void;
+  createRequest: (data: CreateRequestData) => Promise<boolean>;
+}
+
+export function useRequests(): UseRequestsReturn {
+  const { user, profile } = useAuth();
+  const [requests, setRequests] = useState<MockRequest[]>(() => generateMockRequests());
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!supabase || !user) return;
+
+    let cancelled = false;
+
+    const fetchRequests = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        let query = supabase!.from('requests').select('*');
+
+        if (profile?.role === 'hospital_staff' && profile.hospital_id) {
+          query = query.eq('hospital_id', profile.hospital_id);
+        } else if (profile?.role === 'paramedic') {
+          query = query.eq('paramedic_id', user.id);
+        }
+
+        const { data, error: fetchError } = await query.order('requested_at', { ascending: false });
+        if (fetchError) throw fetchError;
+        if (cancelled) return;
+
+        const mapped: MockRequest[] = (data ?? []).map((r: Record<string, unknown>) => ({
+          id: `RQ-${(r.id as string).slice(0, 4).toUpperCase()}`,
+          time: new Date(r.requested_at as string),
+          severity: r.severity as number,
+          distanceKm: Number(r.distance_km ?? 0),
+          symptom: r.symptom as string,
+          status: dbStatusToFrontend(r.status as string),
+          patientAge: r.patient_age ? `${r.patient_age}세` : undefined,
+          allergies: (r.allergies as string[] | null)?.length ? (r.allergies as string[]) : undefined,
+          eta: r.eta_minutes as number | undefined,
+          _supabaseId: r.id as string,
+        }));
+
+        setRequests(mapped);
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to fetch requests');
+          setRequests(generateMockRequests());
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    fetchRequests();
+
+    const channel = supabase!
+      .channel('requests-changes')
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'requests' }, () => {
+        fetchRequests();
+      })
+      .subscribe();
+
+    return () => {
+      cancelled = true;
+      channel.unsubscribe();
+    };
+  }, [user, profile?.hospital_id, profile?.role]);
+
+  const updateRequestStatus = useCallback(
+    (requestId: string, status: MockRequest['status']) => {
+      setRequests(prev => prev.map(r => (r.id === requestId ? { ...r, status } : r)));
+    },
+    [],
+  );
+
+  const createRequest = useCallback(
+    async (data: CreateRequestData): Promise<boolean> => {
+      if (!supabase || !user) return true; // Demo mode: always succeeds
+
+      try {
+        const { error: insertError } = await supabase.from('requests').insert({
+          paramedic_id: user.id,
+          symptom: data.symptom,
+          severity: data.severity,
+          priority: data.priority,
+          patient_name: data.patientName,
+          patient_age: data.patientAge,
+          patient_gender: data.patientGender,
+          vitals: data.vitals ?? {},
+          location_text: data.locationText,
+          notes: data.notes,
+        });
+
+        if (insertError) throw insertError;
+        return true;
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to create request');
+        return false;
+      }
+    },
+    [user],
+  );
+
+  return { requests, loading, error, updateRequestStatus, createRequest };
+}
+
+function dbStatusToFrontend(status: string): MockRequest['status'] {
+  switch (status) {
+    case 'en_route': return 'enRoute';
+    case 'cancelled': return 'cancelled';
+    default: return status as MockRequest['status'];
+  }
+}

--- a/src/hooks/useStaff.ts
+++ b/src/hooks/useStaff.ts
@@ -1,0 +1,103 @@
+import { useState, useEffect, useCallback } from 'react';
+import { supabase } from '../lib/supabase';
+import { useAuth } from '../contexts/AuthContext';
+import { mockStaff, type StaffMember } from '../mocks/staffData';
+
+interface UseStaffReturn {
+  staff: StaffMember[];
+  loading: boolean;
+  error: string | null;
+  updateStaffStatus: (staffId: string, status: StaffMember['status']) => void;
+}
+
+// DB uses underscores for enum values, frontend uses hyphens
+const dbStatusToFrontend = (s: string): StaffMember['status'] =>
+  s.replace(/_/g, '-') as StaffMember['status'];
+
+const frontendStatusToDb = (s: string): string =>
+  s.replace(/-/g, '_');
+
+export function useStaff(): UseStaffReturn {
+  const { profile } = useAuth();
+  const [staff, setStaff] = useState<StaffMember[]>(mockStaff);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!supabase || !profile?.hospital_id) return;
+
+    let cancelled = false;
+
+    const fetchStaff = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const { data, error: fetchError } = await supabase!
+          .from('staff')
+          .select('*')
+          .eq('hospital_id', profile.hospital_id!)
+          .order('name');
+
+        if (fetchError) throw fetchError;
+        if (cancelled) return;
+
+        const mapped: StaffMember[] = (data ?? []).map((s: Record<string, unknown>) => ({
+          id: (s.id as string).slice(0, 6).toUpperCase(),
+          name: s.name as string,
+          role: s.role as StaffMember['role'],
+          department: (s.department as string) ?? '-',
+          shift: s.shift as StaffMember['shift'],
+          status: dbStatusToFrontend(s.status as string),
+          phone: (s.phone as string) ?? '-',
+          email: (s.email as string) ?? '-',
+          specialization: s.specialization as string | undefined,
+          yearsOfExperience: (s.years_of_experience as number) ?? 0,
+          currentLocation: (s.current_location as string) ?? '-',
+          shiftStart: s.shift_start ? (s.shift_start as string).slice(0, 5) : '-',
+          shiftEnd: s.shift_end ? (s.shift_end as string).slice(0, 5) : '-',
+          certifications: (s.certifications as string[]) ?? [],
+          emergencyContact: (s.emergency_contact as string) ?? '-',
+          _supabaseId: s.id as string,
+        }));
+
+        setStaff(mapped);
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to fetch staff');
+          setStaff(mockStaff);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    fetchStaff();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [profile?.hospital_id]);
+
+  const updateStaffStatus = useCallback(
+    (staffId: string, status: StaffMember['status']) => {
+      setStaff(prev => prev.map(s => (s.id === staffId ? { ...s, status } : s)));
+
+      if (supabase) {
+        const member = staff.find(s => s.id === staffId);
+        const supabaseId = member?._supabaseId;
+        if (supabaseId) {
+          supabase
+            .from('staff')
+            .update({ status: frontendStatusToDb(status) })
+            .eq('id', supabaseId)
+            .then(({ error: err }) => {
+              if (err) console.error('Staff status update failed:', err);
+            });
+        }
+      }
+    },
+    [staff],
+  );
+
+  return { staff, loading, error, updateStaffStatus };
+}

--- a/src/mocks/bedData.ts
+++ b/src/mocks/bedData.ts
@@ -12,6 +12,7 @@ export interface BedInfo {
   equipment: string[];
   lastCleaned: string;
   notes?: string;
+  _supabaseId?: string;  // Supabase에서 fetch한 경우에만 존재
 }
 
 export const mockBeds: BedInfo[] = [

--- a/src/mocks/equipmentData.ts
+++ b/src/mocks/equipmentData.ts
@@ -13,6 +13,7 @@ export interface Equipment {
   alerts: string[];
   assignedTo?: string;
   notes?: string;
+  _supabaseId?: string;  // Supabase에서 fetch한 경우에만 존재
 }
 
 export const mockEquipment: Equipment[] = [

--- a/src/mocks/staffData.ts
+++ b/src/mocks/staffData.ts
@@ -14,6 +14,7 @@ export interface StaffMember {
   shiftEnd: string;
   certifications: string[];
   emergencyContact: string;
+  _supabaseId?: string;  // Supabase에서 fetch한 경우에만 존재
 }
 
 export const mockStaff: StaffMember[] = [

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_SUPABASE_URL: string;
+  readonly VITE_SUPABASE_ANON_KEY: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary
- **#44 에러/로딩 상태 처리 결함**: 4개 관리 페이지(BedManagement, PatientDetails, StaffManagement, EquipmentStatus)에서 렌더링 중 toast.error 호출을 useEffect로 이동하고, error 시 조기 return + 에러 UI 표시 추가. HospitalDashboard/ParamedicDashboard에서 loading/error를 destructure하여 적절한 UI 피드백 제공.
- **#45 타입-스키마 불일치**: MockRequest에 'cancelled' 상태 추가, useStaff의 replace를 정규식 /g 플래그로 변경, BedInfo/StaffMember/Equipment/MockRequest/MockHospital에 _supabaseId 필드 추가, display_name 타입을 string으로 변경(NOT NULL), role 캐스팅에 검증 로직 추가, vite-env.d.ts 생성하여 import.meta.env 타입 확장.

## Changes
- 6개 컴포넌트에 hooks 연동 + error/loading 상태 처리 개선
- 6개 hooks 파일 생성 (useBeds, usePatients, useStaff, useEquipment, useRequests, useHospitals)
- 4개 mock 데이터 인터페이스에 _supabaseId 선택적 필드 추가
- AuthContext: display_name 타입 변경, role 검증 로직 추가
- vite-env.d.ts 생성으로 환경 변수 타입 안전성 확보
- 테스트 업데이트 (cancelled 상태 추가)

## Test plan
- [x] `npx tsc --noEmit` 통과 (pre-existing PatientRequest.tsx 오류만 잔존)
- [x] `npx vitest run` 14/14 테스트 통과

Closes #44
Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)