### PR TITLE
fix: AuthContext 초기화 결함 수정 (#43)

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -2,6 +2,7 @@ import { createContext, useContext, useEffect, useState, useCallback } from 'rea
 import type { User, Session } from '@supabase/supabase-js';
 import { supabase, explicitDemoMode, isEnvMissing } from '../lib/supabase';
 import type { UserRole } from '../types/database';
+import { toast } from 'sonner';
 
 export type { UserRole };
 
@@ -82,37 +83,27 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       return;
     }
 
-    // Normal Supabase auth flow
-    supabase.auth.getSession()
-      .then(({ data: { session: currentSession }, error }) => {
-        if (error) {
-          console.error('Failed to get session:', error.message);
-          setLoading(false);
-          return;
-        }
-
-        setSession(currentSession);
-        setUser(currentSession?.user ?? null);
-
-        if (currentSession?.user) {
-          fetchProfile(currentSession.user.id).finally(() => setLoading(false));
-        } else {
-          setLoading(false);
-        }
-      });
-
-    // Listen for auth changes
+    // Use only onAuthStateChange to avoid race condition between
+    // getSession() and onAuthStateChange (Supabase recommended pattern).
+    // The INITIAL_SESSION event fires once on setup with the current session,
+    // eliminating the need for a separate getSession() call.
     const { data: { subscription } } = supabase.auth.onAuthStateChange(
       async (_event, newSession) => {
-        setSession(newSession);
-        setUser(newSession?.user ?? null);
+        try {
+          setSession(newSession);
+          setUser(newSession?.user ?? null);
 
-        if (newSession?.user) {
-          await fetchProfile(newSession.user.id);
-        } else {
+          if (newSession?.user) {
+            await fetchProfile(newSession.user.id);
+          } else {
+            setProfile(null);
+          }
+        } catch (err) {
+          console.error('Error handling auth state change:', err);
           setProfile(null);
+        } finally {
+          setLoading(false);
         }
-        setLoading(false);
       }
     );
 
@@ -122,17 +113,20 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, [fetchProfile]);
 
   const signOut = useCallback(async () => {
+    // Always force local cleanup regardless of server-side result
+    setUser(null);
+    setSession(null);
+    setProfile(null);
+
     try {
       const { error } = await supabase.auth.signOut();
       if (error) {
         console.error('Sign out failed:', error.message);
+        toast.error('로그아웃 중 오류가 발생했습니다. 다시 시도해주세요.');
       }
     } catch (err) {
       console.error('Unexpected error during sign out:', err);
-    } finally {
-      setUser(null);
-      setSession(null);
-      setProfile(null);
+      toast.error('로그아웃 중 예기치 않은 오류가 발생했습니다.');
     }
   }, []);
 


### PR DESCRIPTION
## Summary

Closes #43

`AuthContext`의 세션 초기화 로직에서 발견된 3가지 결함을 수정합니다:

- **경쟁 조건 제거**: `getSession()` 호출을 제거하고 `onAuthStateChange`의 `INITIAL_SESSION` 이벤트만 사용하여 두 경로가 독립적으로 `setLoading(false)`를 호출하는 경쟁 조건을 해결
- **에러 처리 강화**: `onAuthStateChange` 콜백을 `try/catch/finally`로 감싸 에러 발생 시에도 `setLoading(false)`가 반드시 실행되도록 보장
- **signOut 에러 처리**: 로컬 상태 정리(setUser/setSession/setProfile)를 signOut API 호출 전에 수행하여 서버 요청 실패 시에도 로컬 로그아웃이 보장되고, 실패 시 toast 알림 표시

## Test plan

- [ ] 정상적인 로그인/로그아웃 플로우가 동작하는지 확인
- [ ] 네트워크 오류 시 loading 상태가 무한히 true로 남지 않는지 확인
- [ ] signOut API 실패 시 로컬 상태가 정리되고 toast 에러 메시지가 표시되는지 확인
- [ ] 페이지 새로고침 시 세션이 올바르게 복원되는지 확인
- [ ] 데모 모드와 환경 변수 누락 시 기존 동작이 유지되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)