### PR TITLE
fix: DB 상태 업데이트 반영 (#40)

### DIFF
--- a/src/components/hospital/PatientDetails.tsx
+++ b/src/components/hospital/PatientDetails.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
 import { Button } from "../ui/button";
 import { Badge } from "../ui/badge";
@@ -10,6 +10,7 @@ import { Label } from "../ui/label";
 import { Textarea } from "../ui/textarea";
 import { Separator } from "../ui/separator";
 import { toast } from "sonner";
+import { supabase } from "@/lib/supabase";
 import { getSeverityText, getPatientStatusText } from "../../utils/statusHelpers";
 import { usePatients } from "@/hooks/usePatients";
 import { LoadingState } from "../common/LoadingState";
@@ -54,6 +55,9 @@ export function PatientDetails() {
   const [dialogOpen, setDialogOpen] = useState(false);
   const [filterSeverity, setFilterSeverity] = useState<string>('all');
   const [filterStatus, setFilterStatus] = useState<string>('all');
+  const [dialogNotes, setDialogNotes] = useState('');
+  const [dialogStatus, setDialogStatus] = useState<PatientStatus | ''>('');
+  const [saving, setSaving] = useState(false);
 
   const filteredPatients = patients.filter(patient => {
     const matchesSearch = patient.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
@@ -71,12 +75,36 @@ export function PatientDetails() {
 
   const handleViewDetails = (patient: Patient) => {
     setSelectedPatient(patient);
+    setDialogNotes(patient.notes ?? '');
+    setDialogStatus(patient.status);
   };
 
-  const handleUpdateStatus = (patientId: string, newStatus: string) => {
-    updatePatientStatus(patientId, newStatus as PatientStatus);
-    toast.success(`환자 ${patientId}의 상태가 ${newStatus}로 업데이트되었습니다.`);
-  };
+  const handleSaveNotes = useCallback(async () => {
+    if (!selectedPatient) return;
+    setSaving(true);
+    try {
+      const { error } = await supabase
+        .from('patients')
+        .update({ notes: dialogNotes })
+        .eq('id', selectedPatient.id);
+
+      if (error) {
+        toast.error(`환자 정보 저장 실패: ${error.message}`);
+      } else {
+        toast.success('환자 정보가 저장되었습니다.');
+        await refetch();
+      }
+    } catch {
+      toast.error('환자 정보 저장 중 오류가 발생했습니다.');
+    } finally {
+      setSaving(false);
+    }
+  }, [selectedPatient, dialogNotes, refetch]);
+
+  const handleUpdateStatus = useCallback(async (patientId: string, newStatus: PatientStatus) => {
+    await updatePatientStatus(patientId, newStatus);
+    toast.success(`환자 상태가 ${getPatientStatusText(newStatus)}(으)로 업데이트되었습니다.`);
+  }, [updatePatientStatus]);
 
   return (
     <LoadingState loading={loading} error={error} onRetry={refetch}>
@@ -314,15 +342,40 @@ export function PatientDetails() {
                     id="notes"
                     placeholder="환자 상태, 치료 계획 등을 기록하세요..."
                     className="mt-2"
+                    value={dialogNotes}
+                    onChange={(e) => setDialogNotes(e.target.value)}
                   />
                 </div>
 
-                <div className="flex justify-end gap-2">
-                  <Button variant="outline" onClick={() => toast.success("환자 정보가 저장되었습니다.")}>
-                    저장
-                  </Button>
-                  <Button onClick={() => handleUpdateStatus(selectedPatient.id, "updated")}>
-                    상태 업데이트
+                <div className="flex items-end justify-between gap-4">
+                  <div className="flex items-center gap-2">
+                    <Label className="text-sm text-muted-foreground whitespace-nowrap">상태 변경</Label>
+                    <Select value={dialogStatus} onValueChange={(v) => setDialogStatus(v as PatientStatus)}>
+                      <SelectTrigger className="w-[130px]">
+                        <SelectValue placeholder="상태 선택" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="waiting">대기중</SelectItem>
+                        <SelectItem value="treating">치료중</SelectItem>
+                        <SelectItem value="stable">안정</SelectItem>
+                        <SelectItem value="discharged">퇴원</SelectItem>
+                      </SelectContent>
+                    </Select>
+                    <Button
+                      onClick={() => {
+                        if (dialogStatus && dialogStatus !== selectedPatient.status) {
+                          handleUpdateStatus(selectedPatient.id, dialogStatus);
+                        } else {
+                          toast.info('변경할 상태를 선택해 주세요.');
+                        }
+                      }}
+                      disabled={!dialogStatus || dialogStatus === selectedPatient.status}
+                    >
+                      상태 업데이트
+                    </Button>
+                  </div>
+                  <Button variant="outline" onClick={handleSaveNotes} disabled={saving}>
+                    {saving ? '저장 중...' : '메모 저장'}
                   </Button>
                 </div>
               </div>

--- a/src/hooks/useBeds.ts
+++ b/src/hooks/useBeds.ts
@@ -13,7 +13,11 @@ export function useBeds() {
   });
 
   const updateBedStatus = useCallback(async (bedId: string, status: BedStatus) => {
-    setData(prev => prev.map(b => b.id === bedId ? { ...b, status } : b));
+    let previousData: Bed[] = [];
+    setData(prev => {
+      previousData = prev;
+      return prev.map(b => b.id === bedId ? { ...b, status } : b);
+    });
 
     const { error } = await supabase
       .from('beds')
@@ -22,9 +26,9 @@ export function useBeds() {
 
     if (error) {
       toast.error(`병상 상태 변경 실패: ${error.message}`);
-      await refetch();
+      setData(previousData);
     }
-  }, [setData, refetch]);
+  }, [setData]);
 
   return { beds, loading, error, refetch, updateBedStatus };
 }

--- a/src/hooks/useEquipment.ts
+++ b/src/hooks/useEquipment.ts
@@ -13,7 +13,11 @@ export function useEquipment() {
   });
 
   const updateEquipmentStatus = useCallback(async (equipmentId: string, status: EquipmentStatus) => {
-    setData(prev => prev.map(e => e.id === equipmentId ? { ...e, status } : e));
+    let previousData: Equipment[] = [];
+    setData(prev => {
+      previousData = prev;
+      return prev.map(e => e.id === equipmentId ? { ...e, status } : e);
+    });
 
     const { error } = await supabase
       .from('equipment')
@@ -22,9 +26,9 @@ export function useEquipment() {
 
     if (error) {
       toast.error(`장비 상태 변경 실패: ${error.message}`);
-      await refetch();
+      setData(previousData);
     }
-  }, [setData, refetch]);
+  }, [setData]);
 
   return { equipment, loading, error, refetch, updateEquipmentStatus };
 }

--- a/src/hooks/useStaff.ts
+++ b/src/hooks/useStaff.ts
@@ -13,7 +13,11 @@ export function useStaff() {
   });
 
   const updateStaffStatus = useCallback(async (staffId: string, status: StaffStatus) => {
-    setData(prev => prev.map(s => s.id === staffId ? { ...s, status } : s));
+    let previousData: Staff[] = [];
+    setData(prev => {
+      previousData = prev;
+      return prev.map(s => s.id === staffId ? { ...s, status } : s);
+    });
 
     const { error } = await supabase
       .from('staff')
@@ -22,9 +26,9 @@ export function useStaff() {
 
     if (error) {
       toast.error(`직원 상태 변경 실패: ${error.message}`);
-      await refetch();
+      setData(previousData);
     }
-  }, [setData, refetch]);
+  }, [setData]);
 
   return { staff, loading, error, refetch, updateStaffStatus };
 }


### PR DESCRIPTION
## Summary
Closes #40

- **PatientDetails 저장 버튼**: 토스트만 표시하던 것을 실제 Supabase DB에 `notes` 필드를 저장하도록 구현
- **PatientDetails 상태 업데이트**: 하드코딩된 `"updated"` 문자열 대신 유효한 `PatientStatus` 값을 선택할 수 있는 드롭다운 추가
- **useBeds/useStaff/useEquipment**: DB 실패 시 네트워크 재요청(`refetch`) 대신 이전 상태를 메모리에서 즉시 복원하는 optimistic rollback 적용

## Changes
| File | Change |
|------|--------|
| `src/components/hospital/PatientDetails.tsx` | Save button → actual DB write; status update → proper selector |
| `src/hooks/useBeds.ts` | In-memory optimistic rollback on failure |
| `src/hooks/useStaff.ts` | In-memory optimistic rollback on failure |
| `src/hooks/useEquipment.ts` | In-memory optimistic rollback on failure |

## Test plan
- [ ] PatientDetails 다이얼로그에서 메모 입력 후 "메모 저장" 클릭 → DB에 반영되는지 확인
- [ ] PatientDetails 다이얼로그에서 상태 드롭다운으로 변경 후 "상태 업데이트" 클릭 → DB에 반영되는지 확인
- [ ] 페이지 새로고침 후에도 변경사항이 유지되는지 확인
- [ ] DB 연결 실패 시 이전 상태로 롤백되는지 확인 (useBeds, useStaff, useEquipment)
- [ ] 에러 토스트가 올바르게 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)