### PR TITLE
fix: [batch-2] 타입수정, Realtime보안, 에러처리, 검증, 접근성, 성능 (#36,#37,#38,#44,#45,#48,#49)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,6 @@
         "embla-carousel-react": "^8.0.2",
         "input-otp": "^1.2.4",
         "lucide-react": "^0.439.0",
-        "motion": "^10.16.2",
         "next-themes": "^0.3.0",
         "react": "^18.3.1",
         "react-day-picker": "^8.10.1",
@@ -1205,64 +1204,6 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
-    "node_modules/@motionone/animation": {
-      "version": "10.18.0",
-      "resolved": "https://registry.npmjs.org/@motionone/animation/-/animation-10.18.0.tgz",
-      "integrity": "sha512-9z2p5GFGCm0gBsZbi8rVMOAJCtw1WqBTIPw3ozk06gDvZInBPIsQcHgYogEJ4yuHJ+akuW8g1SEIOpTOvYs8hw==",
-      "dependencies": {
-        "@motionone/easing": "^10.18.0",
-        "@motionone/types": "^10.17.1",
-        "@motionone/utils": "^10.18.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@motionone/dom": {
-      "version": "10.18.0",
-      "resolved": "https://registry.npmjs.org/@motionone/dom/-/dom-10.18.0.tgz",
-      "integrity": "sha512-bKLP7E0eyO4B2UaHBBN55tnppwRnaE3KFfh3Ps9HhnAkar3Cb69kUCJY9as8LrccVYKgHA+JY5dOQqJLOPhF5A==",
-      "dependencies": {
-        "@motionone/animation": "^10.18.0",
-        "@motionone/generators": "^10.18.0",
-        "@motionone/types": "^10.17.1",
-        "@motionone/utils": "^10.18.0",
-        "hey-listen": "^1.0.8",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@motionone/easing": {
-      "version": "10.18.0",
-      "resolved": "https://registry.npmjs.org/@motionone/easing/-/easing-10.18.0.tgz",
-      "integrity": "sha512-VcjByo7XpdLS4o9T8t99JtgxkdMcNWD3yHU/n6CLEz3bkmKDRZyYQ/wmSf6daum8ZXqfUAgFeCZSpJZIMxaCzg==",
-      "dependencies": {
-        "@motionone/utils": "^10.18.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@motionone/generators": {
-      "version": "10.18.0",
-      "resolved": "https://registry.npmjs.org/@motionone/generators/-/generators-10.18.0.tgz",
-      "integrity": "sha512-+qfkC2DtkDj4tHPu+AFKVfR/C30O1vYdvsGYaR13W/1cczPrrcjdvYCj0VLFuRMN+lP1xvpNZHCRNM4fBzn1jg==",
-      "dependencies": {
-        "@motionone/types": "^10.17.1",
-        "@motionone/utils": "^10.18.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@motionone/types": {
-      "version": "10.17.1",
-      "resolved": "https://registry.npmjs.org/@motionone/types/-/types-10.17.1.tgz",
-      "integrity": "sha512-KaC4kgiODDz8hswCrS0btrVrzyU2CSQKO7Ps90ibBVSQmjkrt2teqta6/sOG59v7+dPnKMAg13jyqtMKV2yJ7A=="
-    },
-    "node_modules/@motionone/utils": {
-      "version": "10.18.0",
-      "resolved": "https://registry.npmjs.org/@motionone/utils/-/utils-10.18.0.tgz",
-      "integrity": "sha512-3XVF7sgyTSI2KWvTf6uLlBJ5iAgRgmvp3bpuOiQJvInd4nZ19ET8lX5unn30SlmRH7hXbBbH+Gxd0m0klJ3Xtw==",
-      "dependencies": {
-        "@motionone/types": "^10.17.1",
-        "hey-listen": "^1.0.8",
-        "tslib": "^2.3.1"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -5173,11 +5114,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/hey-listen": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/hey-listen/-/hey-listen-1.0.8.tgz",
-      "integrity": "sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q=="
-    },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
@@ -5882,17 +5818,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/motion": {
-      "version": "10.18.0",
-      "resolved": "https://registry.npmjs.org/motion/-/motion-10.18.0.tgz",
-      "integrity": "sha512-MVAZZmwM/cp77BrNe1TxTMldxRPjwBNHheU5aPToqT4rJdZxLiADk58H+a0al5jKLxkB0OdgNq6DiVn11cjvIQ==",
-      "dependencies": {
-        "@motionone/animation": "^10.18.0",
-        "@motionone/dom": "^10.18.0",
-        "@motionone/types": "^10.17.1",
-        "@motionone/utils": "^10.18.0"
       }
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "embla-carousel-react": "^8.0.2",
     "input-otp": "^1.2.4",
     "lucide-react": "^0.439.0",
-    "motion": "^10.16.2",
     "next-themes": "^0.3.0",
     "react": "^18.3.1",
     "react-day-picker": "^8.10.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ import {
   User
 } from 'lucide-react';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "./components/ui/dropdown-menu";
+import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger } from "./components/ui/alert-dialog";
 
 const HospitalDashboard = lazy(() => import('./components/hospital/HospitalDashboard').then(m => ({ default: m.HospitalDashboard })));
 const PatientDetails = lazy(() => import('./components/hospital/PatientDetails').then(m => ({ default: m.PatientDetails })));
@@ -216,6 +217,7 @@ function AppContent() {
 
         {/* User Info & Logout (Desktop) */}
         <div className="border-t border-sidebar-border p-3">
+          <AlertDialog>
           {sidebarOpen ? (
             <div className="flex items-center gap-3">
               <div className="p-2 bg-sidebar-accent rounded-lg shrink-0">
@@ -225,27 +227,42 @@ function AppContent() {
                 <p className="text-sm font-medium truncate">{displayName}</p>
                 <p className="text-xs text-sidebar-foreground/50 truncate">{roleLabel}</p>
               </div>
+              <AlertDialogTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="shrink-0 text-sidebar-foreground/70 hover:text-red-500"
+                  aria-label="로그아웃"
+                >
+                  <LogOut size={16} />
+                </Button>
+              </AlertDialogTrigger>
+            </div>
+          ) : (
+            <AlertDialogTrigger asChild>
               <Button
                 variant="ghost"
                 size="sm"
-                onClick={handleSignOut}
-                className="shrink-0 text-sidebar-foreground/70 hover:text-red-500"
+                className="w-full text-sidebar-foreground/70 hover:text-red-500"
                 aria-label="로그아웃"
               >
                 <LogOut size={16} />
               </Button>
-            </div>
-          ) : (
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={handleSignOut}
-              className="w-full text-sidebar-foreground/70 hover:text-red-500"
-              aria-label="로그아웃"
-            >
-              <LogOut size={16} />
-            </Button>
+            </AlertDialogTrigger>
           )}
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>로그아웃 확인</AlertDialogTitle>
+              <AlertDialogDescription>
+                정말 로그아웃하시겠습니까?
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>취소</AlertDialogCancel>
+              <AlertDialogAction onClick={handleSignOut}>로그아웃</AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+          </AlertDialog>
         </div>
       </aside>
 
@@ -264,7 +281,7 @@ function AppContent() {
                   <p className="text-xs text-sidebar-accent-foreground/70">응급실 관리 시스템</p>
                 </div>
               </div>
-              <button onClick={() => setMobileMenuOpen(false)} className="text-sidebar-foreground/70 hover:text-sidebar-foreground">
+              <button onClick={() => setMobileMenuOpen(false)} className="text-sidebar-foreground/70 hover:text-sidebar-foreground" aria-label="메뉴 닫기">
                 <X size={20} />
               </button>
             </div>
@@ -302,15 +319,30 @@ function AppContent() {
                   <p className="text-sm font-medium truncate">{displayName}</p>
                   <p className="text-xs text-sidebar-foreground/50 truncate">{roleLabel}</p>
                 </div>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={handleSignOut}
-                  className="shrink-0 text-sidebar-foreground/70 hover:text-red-500"
-                  aria-label="로그아웃"
-                >
-                  <LogOut size={16} />
-                </Button>
+                <AlertDialog>
+                  <AlertDialogTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="shrink-0 text-sidebar-foreground/70 hover:text-red-500"
+                      aria-label="로그아웃"
+                    >
+                      <LogOut size={16} />
+                    </Button>
+                  </AlertDialogTrigger>
+                  <AlertDialogContent>
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>로그아웃 확인</AlertDialogTitle>
+                      <AlertDialogDescription>
+                        정말 로그아웃하시겠습니까?
+                      </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                      <AlertDialogCancel>취소</AlertDialogCancel>
+                      <AlertDialogAction onClick={handleSignOut}>로그아웃</AlertDialogAction>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
               </div>
             </div>
           </aside>

--- a/src/components/auth/LoginPage.tsx
+++ b/src/components/auth/LoginPage.tsx
@@ -7,6 +7,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../ui
 import { Separator } from '../ui/separator';
 import { Building2, Loader2, Mail } from 'lucide-react';
 import { toast } from 'sonner';
+import { getUserFriendlyError } from '../../utils/errorMessages';
 
 interface LoginPageProps {
   onSwitchToSignup: () => void;
@@ -34,7 +35,7 @@ export function LoginPage({ onSwitchToSignup }: LoginPageProps) {
         } else if (error.message.includes('Email not confirmed')) {
           toast.error('이메일 인증이 완료되지 않았습니다. 이메일을 확인해주세요.');
         } else {
-          toast.error(`로그인 실패: ${error.message}`);
+          toast.error(getUserFriendlyError(error.message));
         }
       } else {
         toast.success('로그인 성공!');
@@ -56,7 +57,7 @@ export function LoginPage({ onSwitchToSignup }: LoginPageProps) {
         },
       });
       if (error) {
-        toast.error(`Google 로그인 실패: ${error.message}`);
+        toast.error(getUserFriendlyError(error.message));
         setLoading(false);
       }
       // No setLoading(false) on success - page will redirect

--- a/src/components/auth/SignupPage.tsx
+++ b/src/components/auth/SignupPage.tsx
@@ -15,6 +15,7 @@ import {
 } from '../ui/select';
 import { Building2, Loader2, UserPlus } from 'lucide-react';
 import { toast } from 'sonner';
+import { getUserFriendlyError } from '../../utils/errorMessages';
 import type { UserRole } from '../../contexts/AuthContext';
 
 interface SignupPageProps {
@@ -115,7 +116,7 @@ export function SignupPage({ onSwitchToLogin }: SignupPageProps) {
         if (error.message.includes('already registered')) {
           toast.error('이미 등록된 이메일입니다. 로그인해주세요.');
         } else {
-          toast.error(`회원가입 실패: ${error.message}`);
+          toast.error(getUserFriendlyError(error.message));
         }
       } else {
         // Link hospital via server-side RPC if hospital_staff
@@ -159,7 +160,7 @@ export function SignupPage({ onSwitchToLogin }: SignupPageProps) {
       });
       if (error) {
         localStorage.removeItem('oauth_signup_meta');
-        toast.error(`Google 회원가입 실패: ${error.message}`);
+        toast.error(getUserFriendlyError(error.message));
         setLoading(false);
       }
     } catch {

--- a/src/components/common/models.ts
+++ b/src/components/common/models.ts
@@ -22,7 +22,7 @@ export interface MockHospital extends Omit<HospitalAvailability, 'hospital_id' |
 // 목 데이터 생성
 export const generateMockRequests = (): MockRequest[] => {
   const symptoms = ['흉통', '호흡곤란', '외상', '복통', '두통', '발열', '의식잃음', '심정지'];
-  const statuses: RequestStatus[] = ['pending', 'matched', 'en_route', 'completed'];
+  const statuses: RequestStatus[] = ['pending', 'matched', 'en_route', 'completed', 'cancelled'];
 
   return Array.from({ length: 12 }, (_, i) => ({
     id: `RQ-${String(1001 + i).padStart(4, '0')}`,

--- a/src/components/hospital/BedManagement.tsx
+++ b/src/components/hospital/BedManagement.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
 import { Button } from "../ui/button";
 import { Badge } from "../ui/badge";
@@ -44,19 +44,19 @@ export function BedManagement() {
 
   const sections = ['A', 'B', 'C'];
 
-  const filteredBeds = beds.filter(bed => {
+  const filteredBeds = useMemo(() => beds.filter(bed => {
     const matchesSection = selectedSection === 'all' || bed.section === selectedSection;
     const matchesStatus = selectedStatus === 'all' || bed.status === selectedStatus;
     return matchesSection && matchesStatus;
-  });
+  }), [beds, selectedSection, selectedStatus]);
 
-  const bedStats = {
+  const bedStats = useMemo(() => ({
     total: beds.length,
     occupied: beds.filter(b => b.status === 'occupied').length,
     available: beds.filter(b => b.status === 'available').length,
     maintenance: beds.filter(b => b.status === 'maintenance').length,
     cleaning: beds.filter(b => b.status === 'cleaning').length
-  };
+  }), [beds]);
 
   const occupancyRate = bedStats.total > 0 ? Math.round((bedStats.occupied / bedStats.total) * 100) : 0;
 
@@ -257,12 +257,12 @@ export function BedManagement() {
               )}
 
               <div className="flex gap-1 pt-2">
-                <Button variant="outline" size="sm" onClick={() => { setSelectedBed(bed); setDialogOpen(true); }}>
+                <Button variant="outline" size="sm" onClick={() => { setSelectedBed(bed); setDialogOpen(true); }} aria-label="병상 설정">
                   <Settings size={14} />
                 </Button>
 
                 {bed.status === 'available' && (
-                  <Button size="sm" onClick={() => handleAssignPatient(bed.id)}>
+                  <Button size="sm" onClick={() => handleAssignPatient(bed.id)} aria-label="환자 배정">
                     <Plus size={14} />
                   </Button>
                 )}

--- a/src/components/hospital/EquipmentStatus.tsx
+++ b/src/components/hospital/EquipmentStatus.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
 import { Button } from "../ui/button";
 import { Badge } from "../ui/badge";
@@ -72,7 +72,7 @@ export function EquipmentStatus() {
   const [selectedEquipment, setSelectedEquipment] = useState<Equipment | null>(null);
   const [dialogOpen, setDialogOpen] = useState(false);
 
-  const filteredEquipment = equipment.filter(item => {
+  const filteredEquipment = useMemo(() => equipment.filter(item => {
     const matchesSearch = item.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
                          item.id.toLowerCase().includes(searchTerm.toLowerCase()) ||
                          (item.model ?? '').toLowerCase().includes(searchTerm.toLowerCase());
@@ -80,15 +80,15 @@ export function EquipmentStatus() {
     const matchesStatus = selectedStatus === 'all' || item.status === selectedStatus;
 
     return matchesSearch && matchesType && matchesStatus;
-  });
+  }), [equipment, searchTerm, selectedType, selectedStatus]);
 
-  const equipmentStats = {
+  const equipmentStats = useMemo(() => ({
     total: equipment.length,
     operational: equipment.filter(e => e.status === 'operational').length,
     maintenance: equipment.filter(e => e.status === 'maintenance').length,
     error: equipment.filter(e => e.status === 'error').length,
     offline: equipment.filter(e => e.status === 'offline').length
-  };
+  }), [equipment]);
 
   const handleAddEquipment = () => {
     toast.success("새 장비 등록 폼이 열렸습니다.");
@@ -193,6 +193,7 @@ export function EquipmentStatus() {
                 value={searchTerm}
                 onChange={(e) => setSearchTerm(e.target.value)}
                 className="pl-10"
+                aria-label="장비 검색"
               />
             </div>
             <Select value={selectedType} onValueChange={setSelectedType}>
@@ -310,17 +311,17 @@ export function EquipmentStatus() {
                 )}
 
                 <div className="flex gap-1 pt-2">
-                  <Button variant="outline" size="sm" onClick={() => { setSelectedEquipment(item); setDialogOpen(true); }}>
+                  <Button variant="outline" size="sm" onClick={() => { setSelectedEquipment(item); setDialogOpen(true); }} aria-label="장비 설정">
                     <Settings size={14} />
                   </Button>
 
                   {item.status === 'error' && (
-                    <Button size="sm" variant="destructive" onClick={() => handleEmergencyAlert(item.id)}>
+                    <Button size="sm" variant="destructive" onClick={() => handleEmergencyAlert(item.id)} aria-label="긴급 알림">
                       <AlertTriangle size={14} />
                     </Button>
                   )}
 
-                  <Button size="sm" variant="outline" onClick={() => handleMaintenanceRequest(item.id)}>
+                  <Button size="sm" variant="outline" onClick={() => handleMaintenanceRequest(item.id)} aria-label="유지보수 요청">
                     <Calendar size={14} />
                   </Button>
                 </div>

--- a/src/components/hospital/HospitalDashboard.tsx
+++ b/src/components/hospital/HospitalDashboard.tsx
@@ -1,10 +1,11 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useCallback } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
 import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
 import { Switch } from "../ui/switch";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../ui/table";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from "../ui/dialog";
+import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "../ui/alert-dialog";
 import { InfoCard } from "../common/InfoCard";
 import { useRequests } from "@/hooks/useRequests";
 import { useBeds } from "@/hooks/useBeds";
@@ -36,23 +37,32 @@ const recentAlerts = [
 
 export function HospitalDashboard() {
   const [accepting, setAccepting] = useState(true);
+  const [acceptingConfirmOpen, setAcceptingConfirmOpen] = useState(false);
+  const [pendingAccepting, setPendingAccepting] = useState(true);
   const { requests: dbRequests, loading, error, refetch, updateRequestStatus } = useRequests();
   const { beds } = useBeds();
   const [selectedSeverity, setSelectedSeverity] = useState('all');
 
-  const handleAcceptingToggle = (isAccepting: boolean) => {
-    setAccepting(isAccepting);
-    toast(isAccepting ? "환자 수용을 시작합니다" : "환자 수용을 중단합니다");
-  };
+  const handleAcceptingToggleRequest = useCallback((isAccepting: boolean) => {
+    setPendingAccepting(isAccepting);
+    setAcceptingConfirmOpen(true);
+  }, []);
+
+  const handleAcceptingConfirm = useCallback(() => {
+    setAccepting(pendingAccepting);
+    toast(pendingAccepting ? "환자 수용을 시작합니다" : "환자 수용을 중단합니다");
+    setAcceptingConfirmOpen(false);
+  }, [pendingAccepting]);
 
   const handleRequestAction = (requestId: string, action: 'accept' | 'hold') => {
     updateRequestStatus(requestId, action === 'accept' ? 'matched' : 'pending');
     toast(action === 'accept' ? "요청을 수락했습니다" : "요청을 보류했습니다");
   };
 
-  const filteredRequests = selectedSeverity === 'all'
+  const filteredRequests = useMemo(() => selectedSeverity === 'all'
     ? dbRequests.filter(req => req.status === 'pending')
-    : dbRequests.filter(req => req.status === 'pending' && req.severity.toString() === selectedSeverity);
+    : dbRequests.filter(req => req.status === 'pending' && req.severity.toString() === selectedSeverity),
+  [dbRequests, selectedSeverity]);
 
   const kpiData = useMemo(() => {
     const availableBeds = beds.filter(b => b.status === 'available').length;
@@ -135,9 +145,25 @@ export function HospitalDashboard() {
             </Badge>
             <Switch
               checked={accepting}
-              onCheckedChange={handleAcceptingToggle}
+              onCheckedChange={handleAcceptingToggleRequest}
               aria-label="환자 수용 상태 전환"
             />
+            <AlertDialog open={acceptingConfirmOpen} onOpenChange={setAcceptingConfirmOpen}>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>수용 상태 변경 확인</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    {pendingAccepting
+                      ? '환자 수용을 시작하시겠습니까?'
+                      : '환자 수용을 중단하시겠습니까? 새로운 환자 요청을 받을 수 없게 됩니다.'}
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>취소</AlertDialogCancel>
+                  <AlertDialogAction onClick={handleAcceptingConfirm}>확인</AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
           </div>
         </div>
       </div>

--- a/src/components/hospital/PatientDetails.tsx
+++ b/src/components/hospital/PatientDetails.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useMemo } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
 import { Button } from "../ui/button";
 import { Badge } from "../ui/badge";
@@ -10,6 +10,7 @@ import { Label } from "../ui/label";
 import { Textarea } from "../ui/textarea";
 import { Separator } from "../ui/separator";
 import { toast } from "sonner";
+import { getUserFriendlyError } from "../../utils/errorMessages";
 import { supabase } from "@/lib/supabase";
 import { getSeverityText, getPatientStatusText } from "../../utils/statusHelpers";
 import { usePatients } from "@/hooks/usePatients";
@@ -59,7 +60,7 @@ export function PatientDetails() {
   const [dialogStatus, setDialogStatus] = useState<PatientStatus | ''>('');
   const [saving, setSaving] = useState(false);
 
-  const filteredPatients = patients.filter(patient => {
+  const filteredPatients = useMemo(() => patients.filter(patient => {
     const matchesSearch = patient.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
                          patient.id.toLowerCase().includes(searchTerm.toLowerCase()) ||
                          (patient.diagnosis ?? '').toLowerCase().includes(searchTerm.toLowerCase());
@@ -67,7 +68,7 @@ export function PatientDetails() {
     const matchesStatus = filterStatus === 'all' || patient.status === filterStatus;
 
     return matchesSearch && matchesSeverity && matchesStatus;
-  });
+  }), [patients, searchTerm, filterSeverity, filterStatus]);
 
   const handleAddPatient = () => {
     toast.success("새 환자 등록 폼이 열렸습니다.");
@@ -89,7 +90,7 @@ export function PatientDetails() {
         .eq('id', selectedPatient.id);
 
       if (error) {
-        toast.error(`환자 정보 저장 실패: ${error.message}`);
+        toast.error(getUserFriendlyError(error.message));
       } else {
         toast.success('환자 정보가 저장되었습니다.');
         await refetch();
@@ -132,6 +133,7 @@ export function PatientDetails() {
                 value={searchTerm}
                 onChange={(e) => setSearchTerm(e.target.value)}
                 className="pl-10"
+                aria-label="환자 검색"
               />
             </div>
             <Select value={filterSeverity} onValueChange={setFilterSeverity}>

--- a/src/components/hospital/StaffManagement.tsx
+++ b/src/components/hospital/StaffManagement.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
 import { Button } from "../ui/button";
 import { Badge } from "../ui/badge";
@@ -91,7 +91,7 @@ export function StaffManagement() {
   const [selectedStaff, setSelectedStaff] = useState<Staff | null>(null);
   const [dialogOpen, setDialogOpen] = useState(false);
 
-  const filteredStaff = staff.filter(member => {
+  const filteredStaff = useMemo(() => staff.filter(member => {
     const matchesSearch = member.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
                          member.id.toLowerCase().includes(searchTerm.toLowerCase()) ||
                          (member.department ?? '').toLowerCase().includes(searchTerm.toLowerCase());
@@ -99,15 +99,15 @@ export function StaffManagement() {
     const matchesStatus = selectedStatus === 'all' || member.status === selectedStatus;
 
     return matchesSearch && matchesRole && matchesStatus;
-  });
+  }), [staff, searchTerm, selectedRole, selectedStatus]);
 
-  const staffStats = {
+  const staffStats = useMemo(() => ({
     total: staff.length,
     onDuty: staff.filter(s => s.status === 'on_duty').length,
     offDuty: staff.filter(s => s.status === 'off_duty').length,
     onBreak: staff.filter(s => s.status === 'break').length,
     emergency: staff.filter(s => s.status === 'emergency').length
-  };
+  }), [staff]);
 
   const handleAddStaff = () => {
     toast.success("새 직원 등록 폼이 열렸습니다.");
@@ -469,9 +469,27 @@ export function StaffManagement() {
                       <SelectItem value="emergency">응급호출</SelectItem>
                     </SelectContent>
                   </Select>
-                  <Button variant="destructive" onClick={() => handleEmergencyCall(selectedStaff.id)}>
-                    응급호출
-                  </Button>
+                  <AlertDialog>
+                    <AlertDialogTrigger asChild>
+                      <Button variant="destructive">
+                        응급호출
+                      </Button>
+                    </AlertDialogTrigger>
+                    <AlertDialogContent>
+                      <AlertDialogHeader>
+                        <AlertDialogTitle>응급호출 확인</AlertDialogTitle>
+                        <AlertDialogDescription>
+                          {selectedStaff.name}에게 응급호출을 발송하시겠습니까? 이 작업은 취소할 수 없습니다.
+                        </AlertDialogDescription>
+                      </AlertDialogHeader>
+                      <AlertDialogFooter>
+                        <AlertDialogCancel>취소</AlertDialogCancel>
+                        <AlertDialogAction onClick={() => handleEmergencyCall(selectedStaff.id)}>
+                          호출 발송
+                        </AlertDialogAction>
+                      </AlertDialogFooter>
+                    </AlertDialogContent>
+                  </AlertDialog>
                 </div>
               </div>
             </>

--- a/src/components/paramedic/ParamedicDashboard.tsx
+++ b/src/components/paramedic/ParamedicDashboard.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
 import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
@@ -43,7 +43,7 @@ export function ParamedicDashboard() {
     toast(online ? "온라인 상태로 전환되었습니다" : "오프라인 상태로 전환되었습니다");
   };
 
-  const getStatusCounts = () => {
+  const statusCounts = useMemo(() => {
     const counts = dbRequests.reduce((acc, req) => {
       acc[req.status] = (acc[req.status] || 0) + 1;
       return acc;
@@ -55,9 +55,7 @@ export function ParamedicDashboard() {
       enRoute: counts.en_route || 0,
       completed: counts.completed || 0
     };
-  };
-
-  const statusCounts = getStatusCounts();
+  }, [dbRequests]);
 
   const getEventColorBar = (type: string) => {
     switch (type) {
@@ -94,6 +92,7 @@ export function ParamedicDashboard() {
             <Switch
               checked={isOnline}
               onCheckedChange={handleStatusToggle}
+              aria-label="온라인/오프라인 상태 전환"
             />
           </div>
         </div>

--- a/src/components/paramedic/PatientRequest.tsx
+++ b/src/components/paramedic/PatientRequest.tsx
@@ -127,7 +127,7 @@ export function PatientRequest() {
         toast.error("환자 나이를 입력해주세요.");
         return;
       }
-      const ageNum = Number(newPatientForm.age);
+      const ageNum = parseInt(newPatientForm.age, 10);
       if (isNaN(ageNum) || ageNum < 0 || ageNum > 150) {
         toast.error("나이는 0~150 사이의 숫자여야 합니다.");
         return;

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -100,8 +100,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         return;
       }
 
+      const validRoles: UserRole[] = ['hospital_staff', 'paramedic'];
+      const role: UserRole = validRoles.includes(data.role as UserRole)
+        ? (data.role as UserRole)
+        : 'paramedic';
+
       setProfile({
-        role: data.role as UserRole,
+        role,
         hospital_id: data.hospital_id,
         display_name: data.display_name,
       });

--- a/src/hooks/useBeds.ts
+++ b/src/hooks/useBeds.ts
@@ -4,6 +4,7 @@ import { useSupabaseQuery } from './useSupabaseQuery';
 import { mockBeds } from '@/mocks/bedData';
 import type { Bed, BedStatus } from '@/types/database';
 import { toast } from 'sonner';
+import { getUserFriendlyError } from '@/utils/errorMessages';
 
 export function useBeds() {
   const { data: beds, loading, error, refetch, setData } = useSupabaseQuery<Bed>({
@@ -25,7 +26,7 @@ export function useBeds() {
       .eq('id', bedId);
 
     if (error) {
-      toast.error(`병상 상태 변경 실패: ${error.message}`);
+      toast.error(getUserFriendlyError(error.message));
       setData(previousData);
     }
   }, [setData]);

--- a/src/hooks/useEquipment.ts
+++ b/src/hooks/useEquipment.ts
@@ -4,6 +4,7 @@ import { useSupabaseQuery } from './useSupabaseQuery';
 import { mockEquipment } from '@/mocks/equipmentData';
 import type { Equipment, EquipmentStatus } from '@/types/database';
 import { toast } from 'sonner';
+import { getUserFriendlyError } from '@/utils/errorMessages';
 
 export function useEquipment() {
   const { data: equipment, loading, error, refetch, setData } = useSupabaseQuery<Equipment>({
@@ -25,7 +26,7 @@ export function useEquipment() {
       .eq('id', equipmentId);
 
     if (error) {
-      toast.error(`장비 상태 변경 실패: ${error.message}`);
+      toast.error(getUserFriendlyError(error.message));
       setData(previousData);
     }
   }, [setData]);

--- a/src/hooks/usePatients.ts
+++ b/src/hooks/usePatients.ts
@@ -4,6 +4,7 @@ import { useSupabaseQuery } from './useSupabaseQuery';
 import { mockPatients } from '@/mocks/patientData';
 import type { Patient, PatientStatus } from '@/types/database';
 import { toast } from 'sonner';
+import { getUserFriendlyError } from '@/utils/errorMessages';
 
 export function usePatients() {
   const { data: patients, loading, error, refetch, setData } = useSupabaseQuery<Patient>({
@@ -21,7 +22,7 @@ export function usePatients() {
       .eq('id', patientId);
 
     if (error) {
-      toast.error(`환자 상태 변경 실패: ${error.message}`);
+      toast.error(getUserFriendlyError(error.message));
       await refetch();
     }
   }, [setData, refetch]);

--- a/src/hooks/useRequests.ts
+++ b/src/hooks/useRequests.ts
@@ -4,6 +4,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import type { Request, RequestStatus, RequestPriority } from '@/types/database';
 import type { RealtimeChannel } from '@supabase/supabase-js';
 import { toast } from 'sonner';
+import { getUserFriendlyError } from '@/utils/errorMessages';
 
 interface UseRequestsResult {
   requests: Request[];
@@ -127,7 +128,7 @@ export function useRequests(): UseRequestsResult {
       .eq('id', requestId);
 
     if (error) {
-      toast.error(`요청 상태 변경 실패: ${error.message}`);
+      toast.error(getUserFriendlyError(error.message));
       await fetchRequests();
     }
   }, [fetchRequests]);
@@ -138,13 +139,27 @@ export function useRequests(): UseRequestsResult {
       return;
     }
 
+    // Client-side validation
+    if (data.patient_age != null && (data.patient_age < 0 || data.patient_age > 150)) {
+      toast.error('나이는 0~150 사이의 숫자여야 합니다.');
+      return;
+    }
+    if (data.severity < 1 || data.severity > 5) {
+      toast.error('중증도는 1~5 사이의 값이어야 합니다.');
+      return;
+    }
+    if (data.patient_name && data.patient_name.trim().length > 100) {
+      toast.error('환자 이름은 100자 이내여야 합니다.');
+      return;
+    }
+
     const { error } = await supabase.from('requests').insert({
       paramedic_id: user.id,
       ...data,
     });
 
     if (error) {
-      toast.error(`요청 전송 실패: ${error.message}`);
+      toast.error(getUserFriendlyError(error.message));
       throw error;
     }
 

--- a/src/hooks/useStaff.ts
+++ b/src/hooks/useStaff.ts
@@ -4,6 +4,7 @@ import { useSupabaseQuery } from './useSupabaseQuery';
 import { mockStaff } from '@/mocks/staffData';
 import type { Staff, StaffStatus } from '@/types/database';
 import { toast } from 'sonner';
+import { getUserFriendlyError } from '@/utils/errorMessages';
 
 export function useStaff() {
   const { data: staff, loading, error, refetch, setData } = useSupabaseQuery<Staff>({
@@ -25,7 +26,7 @@ export function useStaff() {
       .eq('id', staffId);
 
     if (error) {
-      toast.error(`직원 상태 변경 실패: ${error.message}`);
+      toast.error(getUserFriendlyError(error.message));
       setData(previousData);
     }
   }, [setData]);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,13 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+import { ErrorBoundary } from './components/common/ErrorBoundary';
 import App from './App.tsx';
 import './styles/globals.css';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>
   </StrictMode>,
 );

--- a/src/utils/errorMessages.ts
+++ b/src/utils/errorMessages.ts
@@ -1,0 +1,43 @@
+/**
+ * Maps known Supabase/auth error codes to user-friendly Korean messages.
+ * Falls back to a generic message for unknown errors.
+ */
+
+const ERROR_MAP: Record<string, string> = {
+  // Auth errors
+  'Invalid login credentials': '이메일 또는 비밀번호가 올바르지 않습니다.',
+  'Email not confirmed': '이메일 인증이 완료되지 않았습니다. 이메일을 확인해주세요.',
+  'User already registered': '이미 등록된 이메일입니다. 로그인해주세요.',
+  'already registered': '이미 등록된 이메일입니다. 로그인해주세요.',
+  'Signup requires a valid password': '유효한 비밀번호를 입력해주세요.',
+  'Password should be at least 6 characters': '비밀번호는 6자 이상이어야 합니다.',
+  'Email rate limit exceeded': '요청이 너무 많습니다. 잠시 후 다시 시도해주세요.',
+  'Rate limit exceeded': '요청이 너무 많습니다. 잠시 후 다시 시도해주세요.',
+  // DB errors
+  'duplicate key value': '이미 존재하는 데이터입니다.',
+  'violates foreign key constraint': '참조된 데이터가 존재하지 않습니다.',
+  'violates check constraint': '입력값이 허용 범위를 벗어났습니다.',
+  'permission denied': '권한이 없습니다.',
+  'JWT expired': '세션이 만료되었습니다. 다시 로그인해주세요.',
+  // Network
+  'Failed to fetch': '네트워크 오류가 발생했습니다. 인터넷 연결을 확인해주세요.',
+  'NetworkError': '네트워크 오류가 발생했습니다. 인터넷 연결을 확인해주세요.',
+};
+
+const DEFAULT_MESSAGE = '오류가 발생했습니다. 잠시 후 다시 시도해주세요.';
+
+/**
+ * Converts a raw error message (typically from Supabase) into a
+ * user-friendly Korean string. Never exposes raw technical details.
+ */
+export function getUserFriendlyError(rawMessage?: string | null): string {
+  if (!rawMessage) return DEFAULT_MESSAGE;
+
+  for (const [key, friendly] of Object.entries(ERROR_MAP)) {
+    if (rawMessage.includes(key)) {
+      return friendly;
+    }
+  }
+
+  return DEFAULT_MESSAGE;
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,11 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_SUPABASE_URL: string;
+  readonly VITE_SUPABASE_ANON_KEY: string;
+  readonly VITE_DEMO_MODE: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/supabase/migrations/00004_add_validation_constraints.sql
+++ b/supabase/migrations/00004_add_validation_constraints.sql
@@ -1,0 +1,11 @@
+-- Add CHECK constraints for input validation
+-- patient_age: 0~150 range
+-- display_name: 2~50 characters
+
+ALTER TABLE requests
+  ADD CONSTRAINT chk_patient_age
+    CHECK (patient_age IS NULL OR (patient_age >= 0 AND patient_age <= 150));
+
+ALTER TABLE profiles
+  ADD CONSTRAINT chk_display_name_length
+    CHECK (char_length(display_name) >= 2 AND char_length(display_name) <= 50);


### PR DESCRIPTION
## Summary
- #45: Type-schema 불일치 수정 (cancelled 상태, ImportMetaEnv 확장, UserRole 타입 가드)
- #36: Realtime 구독 hospital_id 필터 + 고유 채널명 (useSupabaseQuery에서 이미 처리)
- #37: 프로덕션 sourcemap 비활성화 + 에러 메시지 한국어 매핑 (errorMessages.ts 생성)
- #38: patientAge parseInt radix + 클라이언트측 유효성 검증 + DB CHECK 제약
- #44: 렌더링 중 toast → useEffect (LoadingState 컴포넌트로 이미 처리)
- #48: ErrorBoundary 래핑, 로그아웃/수용상태/응급호출 확인 다이얼로그, aria-label 추가
- #49: useMemo/useCallback 최적화, motion 패키지 제거

closes #36, closes #37, closes #38, closes #44, closes #45, closes #48, closes #49

## Test plan
- [ ] TypeScript 컴파일 확인
- [ ] Demo 모드에서 각 페이지 동작 확인
- [ ] Realtime 구독 필터 동작 확인 (hospital_id 기반)
- [ ] 에러 발생 시 한국어 메시지 표시 확인
- [ ] ErrorBoundary fallback UI 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)