### PR TITLE
feat: 병원 자동 매칭 알고리즘 (거리+병상+대기+수용 점수)

### DIFF
--- a/src/hooks/useRequests.ts
+++ b/src/hooks/useRequests.ts
@@ -156,17 +156,35 @@ export function useRequests(): UseRequestsResult {
       return;
     }
 
-    const { error } = await supabase.from('requests').insert({
+    const { data: inserted, error } = await supabase.from('requests').insert({
       paramedic_id: user.id,
       ...data,
-    });
+    }).select('id').single();
 
     if (error) {
       toast.error(getUserFriendlyError(error.message));
       throw error;
     }
 
-    toast.success('요청이 병원으로 전송되었습니다!');
+    // 자동 매칭 시도
+    if (inserted?.id) {
+      try {
+        const { data: matchResult } = await supabase.rpc('match_hospital_for_request', {
+          p_request_id: inserted.id,
+        });
+        if (matchResult?.matched) {
+          toast.success(`${matchResult.hospital_name}에 매칭되었습니다! (${matchResult.distance_km}km)`);
+        } else {
+          toast.info('요청이 전송되었습니다. 수용 가능한 병원을 찾고 있습니다.');
+        }
+      } catch {
+        // RPC 미구성(데모 등) 시 조용히 넘어감
+        toast.success('요청이 병원으로 전송되었습니다!');
+      }
+    } else {
+      toast.success('요청이 병원으로 전송되었습니다!');
+    }
+
     await fetchRequests();
   }, [user, fetchRequests]);
 

--- a/src/utils/matchHospital.ts
+++ b/src/utils/matchHospital.ts
@@ -1,0 +1,54 @@
+import { calculateDistanceKm } from '@/hooks/useGeolocation';
+import type { MockHospital } from '@/components/common/models';
+
+export interface MatchResult {
+  matched: boolean;
+  hospital?: MockHospital;
+  distance_km?: number;
+  score?: number;
+  reason?: string;
+}
+
+/**
+ * 클라이언트 사이드 병원 매칭 (데모모드 / 오프라인용)
+ *
+ * 점수 = 거리(40%) + 병상(30%) + 대기(20%) + 수용(10%)
+ */
+export function matchHospitalClient(
+  hospitals: MockHospital[],
+  ambulanceLat?: number | null,
+  ambulanceLng?: number | null,
+): MatchResult {
+  const candidates = hospitals.filter(h => h.accepting && h.available_beds > 0);
+
+  if (candidates.length === 0) {
+    return { matched: false, reason: '수용 가능한 병원이 없습니다.' };
+  }
+
+  const scored = candidates.map(h => {
+    let distScore = 0;
+    let distKm: number | null = null;
+
+    if (ambulanceLat != null && ambulanceLng != null && h.latitude != null && h.longitude != null) {
+      distKm = calculateDistanceKm(ambulanceLat, ambulanceLng, h.latitude, h.longitude);
+      distScore = Math.max(0, 40 - distKm * 4);
+    }
+
+    const bedScore = Math.min(30, h.available_beds * 10);
+    const queueScore = Math.max(0, 20 - h.queue * 2);
+    const acceptScore = h.accepting ? 10 : 0;
+    const score = distScore + bedScore + queueScore + acceptScore;
+
+    return { hospital: h, score, distance_km: distKm };
+  });
+
+  scored.sort((a, b) => b.score - a.score);
+  const best = scored[0];
+
+  return {
+    matched: true,
+    hospital: best.hospital,
+    distance_km: best.distance_km ?? undefined,
+    score: Math.round(best.score * 10) / 10,
+  };
+}

--- a/supabase/migrations/00005_matching_algorithm.sql
+++ b/supabase/migrations/00005_matching_algorithm.sql
@@ -1,0 +1,104 @@
+-- 매칭 알고리즘: 요청에 대해 최적 병원을 선정하고 배정
+-- 점수 = 거리 가중치(40%) + 병상 가용률(30%) + 대기 인원(20%) + 수용 상태(10%)
+
+CREATE OR REPLACE FUNCTION match_hospital_for_request(p_request_id uuid)
+RETURNS json AS $$
+DECLARE
+  v_req RECORD;
+  v_best RECORD;
+  v_result json;
+BEGIN
+  -- 요청 정보 조회
+  SELECT id, latitude, longitude, severity, status
+  INTO v_req
+  FROM requests
+  WHERE id = p_request_id;
+
+  IF NOT FOUND THEN
+    RETURN json_build_object('matched', false, 'reason', 'request_not_found');
+  END IF;
+
+  IF v_req.status != 'pending' THEN
+    RETURN json_build_object('matched', false, 'reason', 'already_processed');
+  END IF;
+
+  -- 최적 병원 선정 (점수 높은 순)
+  SELECT
+    h.id AS hospital_id,
+    h.name AS hospital_name,
+    h.latitude,
+    h.longitude,
+    avail.available_beds,
+    h.queue,
+    -- 거리 계산 (Haversine, km)
+    CASE
+      WHEN v_req.latitude IS NOT NULL AND h.latitude IS NOT NULL THEN
+        6371 * acos(
+          LEAST(1.0, GREATEST(-1.0,
+            cos(radians(v_req.latitude)) * cos(radians(h.latitude))
+            * cos(radians(h.longitude) - radians(v_req.longitude))
+            + sin(radians(v_req.latitude)) * sin(radians(h.latitude))
+          ))
+        )
+      ELSE 9999
+    END AS distance_km,
+    -- 종합 점수 (높을수록 좋음)
+    (
+      -- 거리 점수 (가까울수록 높음, 최대 40점)
+      CASE
+        WHEN v_req.latitude IS NOT NULL AND h.latitude IS NOT NULL THEN
+          GREATEST(0, 40 - (
+            6371 * acos(
+              LEAST(1.0, GREATEST(-1.0,
+                cos(radians(v_req.latitude)) * cos(radians(h.latitude))
+                * cos(radians(h.longitude) - radians(v_req.longitude))
+                + sin(radians(v_req.latitude)) * sin(radians(h.latitude))
+              ))
+            )
+          ) * 4)
+        ELSE 0
+      END
+      -- 병상 가용 점수 (최대 30점)
+      + LEAST(30, avail.available_beds * 10)
+      -- 대기 인원 점수 (적을수록 높음, 최대 20점)
+      + GREATEST(0, 20 - h.queue * 2)
+      -- 수용 상태 보너스
+      + CASE WHEN h.accepting THEN 10 ELSE 0 END
+    ) AS score
+  INTO v_best
+  FROM hospitals h
+  LEFT JOIN LATERAL (
+    SELECT COUNT(*) FILTER (WHERE b.status = 'available') AS available_beds
+    FROM beds b WHERE b.hospital_id = h.id
+  ) avail ON true
+  WHERE h.accepting = true
+    AND avail.available_beds > 0
+  ORDER BY score DESC
+  LIMIT 1;
+
+  IF NOT FOUND THEN
+    RETURN json_build_object('matched', false, 'reason', 'no_available_hospital');
+  END IF;
+
+  -- 요청에 병원 배정
+  UPDATE requests
+  SET
+    hospital_id = v_best.hospital_id,
+    status = 'matched',
+    matched_at = NOW(),
+    distance_km = ROUND(v_best.distance_km::numeric, 1),
+    eta_minutes = GREATEST(5, ROUND(v_best.distance_km * 3)::int) -- 대략 km * 3분
+  WHERE id = p_request_id;
+
+  v_result := json_build_object(
+    'matched', true,
+    'hospital_id', v_best.hospital_id,
+    'hospital_name', v_best.hospital_name,
+    'distance_km', ROUND(v_best.distance_km::numeric, 1),
+    'available_beds', v_best.available_beds,
+    'score', ROUND(v_best.score::numeric, 1)
+  );
+
+  RETURN v_result;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;


### PR DESCRIPTION
## Summary
- PostgreSQL 함수 `match_hospital_for_request()` 구현
  - 거리 40% + 병상 30% + 대기 20% + 수용 10% 가중 점수
  - Haversine 거리 계산, ETA 자동 산출
- 요청 생성 즉시 자동 매칭 (RPC 호출)
- 클라이언트 사이드 매칭 함수 (데모모드용)

## Test plan
- [ ] 요청 생성 시 매칭 결과 toast 표시
- [ ] DB에 match_hospital_for_request RPC 등록 후 동작 확인
- [ ] 수용 불가 병원은 매칭 제외 확인
- [ ] 병상 0개 병원은 매칭 제외 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)